### PR TITLE
Fixed naming of the collection following change in the galaxy.yml file

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,3 +1,4 @@
+---
 repository:
   name: fabric-ansible-collection
   default_branch: main

--- a/examples/opensource-stack/templates/ingress/kustomization.yaml
+++ b/examples/opensource-stack/templates/ingress/kustomization.yaml
@@ -15,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 

--- a/roles/endorsing_organization/tasks/create.yml
+++ b/roles/endorsing_organization/tasks/create.yml
@@ -4,193 +4,193 @@
 ---
 - name: Fail if organization MSP ID not specified
   fail:
-    msg: organization_msp_id not specified or is empty
+      msg: organization_msp_id not specified or is empty
   when: not organization_msp_id is defined or not organization_msp_id
 
 - name: Fail if certificate authority admin enrollment ID not specified
   fail:
-    msg: ca_admin_enrollment_id not specified or is empty
+      msg: ca_admin_enrollment_id not specified or is empty
   when: not ca_admin_enrollment_id is defined or not ca_admin_enrollment_id
 
 - name: Fail if certificate authority admin enrollment secret not specified
   fail:
-    msg: ca_admin_enrollment_secret not specified or is empty
+      msg: ca_admin_enrollment_secret not specified or is empty
   when: not ca_admin_enrollment_secret is defined or not ca_admin_enrollment_secret
 
 - name: Fail if organization admin enrollment ID not specified
   fail:
-    msg: organization_admin_enrollment_id not specified or is empty
+      msg: organization_admin_enrollment_id not specified or is empty
   when: not organization_admin_enrollment_id is defined or not organization_admin_enrollment_id
 
 - name: Fail if organization admin enrollment secret not specified
   fail:
-    msg: organization_admin_enrollment_secret not specified or is empty
+      msg: organization_admin_enrollment_secret not specified or is empty
   when: not organization_admin_enrollment_secret is defined or not organization_admin_enrollment_secret
 
 - name: Fail if peer enrollment ID not specified
   fail:
-    msg: peer_enrollment_id not specified or is empty
+      msg: peer_enrollment_id not specified or is empty
   when: not peer_enrollment_id is defined or not peer_enrollment_id
 
 - name: Fail if peer enrollment secret not specified
   fail:
-    msg: peer_enrollment_secret not specified or is empty
+      msg: peer_enrollment_secret not specified or is empty
   when: not peer_enrollment_secret is defined or not peer_enrollment_secret
 
 - name: Create certificate authority
-  hyperledger.fabric-ansible-collection.certificate_authority:
-    state: "{{ state }}"
-    api_endpoint: "{{ api_endpoint }}"
-    api_authtype: "{{ api_authtype }}"
-    api_key: "{{ api_key }}"
-    api_secret: "{{ api_secret | default(omit) }}"
-    api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-    api_timeout: "{{ api_timeout | default(omit) }}"
-    name: "{{ ca_name }}"
-    config_override:
-      ca:
-        registry:
-          maxenrollments: -1
-          identities:
-            - name: "{{ ca_admin_enrollment_id }}"
-              pass: "{{ ca_admin_enrollment_secret }}"
-              type: client
-              maxenrollments: -1
-              attrs:
-                hf.Registrar.Roles: "*"
-                hf.Registrar.DelegateRoles: "*"
-                hf.Revoker: true
-                hf.IntermediateCA: true
-                hf.GenCRL: true
-                hf.Registrar.Attributes: "*"
-                hf.AffiliationMgr: true
-    resources: "{{ ca_resources | default(omit) }}"
-    storage: "{{ ca_storage | default(omit) }}"
-    version: "{{ ca_version | default(omit) }}"
-    wait_timeout: "{{ wait_timeout | default(omit) }}"
+  hyperledger.fabric_ansible_collection.certificate_authority:
+      state: "{{ state }}"
+      api_endpoint: "{{ api_endpoint }}"
+      api_authtype: "{{ api_authtype }}"
+      api_key: "{{ api_key }}"
+      api_secret: "{{ api_secret | default(omit) }}"
+      api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+      api_timeout: "{{ api_timeout | default(omit) }}"
+      name: "{{ ca_name }}"
+      config_override:
+          ca:
+              registry:
+                  maxenrollments: -1
+                  identities:
+                      - name: "{{ ca_admin_enrollment_id }}"
+                        pass: "{{ ca_admin_enrollment_secret }}"
+                        type: client
+                        maxenrollments: -1
+                        attrs:
+                            hf.Registrar.Roles: "*"
+                            hf.Registrar.DelegateRoles: "*"
+                            hf.Revoker: true
+                            hf.IntermediateCA: true
+                            hf.GenCRL: true
+                            hf.Registrar.Attributes: "*"
+                            hf.AffiliationMgr: true
+      resources: "{{ ca_resources | default(omit) }}"
+      storage: "{{ ca_storage | default(omit) }}"
+      version: "{{ ca_version | default(omit) }}"
+      wait_timeout: "{{ wait_timeout | default(omit) }}"
 
 - name: Enroll certificate authority admin
-  hyperledger.fabric-ansible-collection.enrolled_identity:
-    state: "{{ state }}"
-    api_endpoint: "{{ api_endpoint }}"
-    api_authtype: "{{ api_authtype }}"
-    api_key: "{{ api_key }}"
-    api_secret: "{{ api_secret | default(omit) }}"
-    api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-    api_timeout: "{{ api_timeout | default(omit) }}"
-    certificate_authority: "{{ ca_name }}"
-    name: "{{ ca_name }} Admin"
-    enrollment_id: "{{ ca_admin_enrollment_id }}"
-    enrollment_secret: "{{ ca_admin_enrollment_secret }}"
-    path: "{{ ca_admin_identity }}"
+  hyperledger.fabric_ansible_collection.enrolled_identity:
+      state: "{{ state }}"
+      api_endpoint: "{{ api_endpoint }}"
+      api_authtype: "{{ api_authtype }}"
+      api_key: "{{ api_key }}"
+      api_secret: "{{ api_secret | default(omit) }}"
+      api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+      api_timeout: "{{ api_timeout | default(omit) }}"
+      certificate_authority: "{{ ca_name }}"
+      name: "{{ ca_name }} Admin"
+      enrollment_id: "{{ ca_admin_enrollment_id }}"
+      enrollment_secret: "{{ ca_admin_enrollment_secret }}"
+      path: "{{ ca_admin_identity }}"
 
 - name: Register the organization admin
-  hyperledger.fabric-ansible-collection.registered_identity:
-    state: "{{ state }}"
-    api_endpoint: "{{ api_endpoint }}"
-    api_authtype: "{{ api_authtype }}"
-    api_key: "{{ api_key }}"
-    api_secret: "{{ api_secret | default(omit) }}"
-    api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-    api_timeout: "{{ api_timeout | default(omit) }}"
-    certificate_authority: "{{ ca_name }}"
-    registrar: "{{ ca_admin_identity }}"
-    enrollment_id: "{{ organization_admin_enrollment_id }}"
-    enrollment_secret: "{{ organization_admin_enrollment_secret }}"
-    max_enrollments: -1
-    type: admin
+  hyperledger.fabric_ansible_collection.registered_identity:
+      state: "{{ state }}"
+      api_endpoint: "{{ api_endpoint }}"
+      api_authtype: "{{ api_authtype }}"
+      api_key: "{{ api_key }}"
+      api_secret: "{{ api_secret | default(omit) }}"
+      api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+      api_timeout: "{{ api_timeout | default(omit) }}"
+      certificate_authority: "{{ ca_name }}"
+      registrar: "{{ ca_admin_identity }}"
+      enrollment_id: "{{ organization_admin_enrollment_id }}"
+      enrollment_secret: "{{ organization_admin_enrollment_secret }}"
+      max_enrollments: -1
+      type: admin
 
 - name: Register the peer
-  hyperledger.fabric-ansible-collection.registered_identity:
-    state: "{{ state }}"
-    api_endpoint: "{{ api_endpoint }}"
-    api_authtype: "{{ api_authtype }}"
-    api_key: "{{ api_key }}"
-    api_secret: "{{ api_secret | default(omit) }}"
-    api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-    api_timeout: "{{ api_timeout | default(omit) }}"
-    certificate_authority: "{{ ca_name }}"
-    registrar: "{{ ca_admin_identity }}"
-    enrollment_id: "{{ peer_enrollment_id }}"
-    enrollment_secret: "{{ peer_enrollment_secret }}"
-    max_enrollments: -1
-    type: peer
+  hyperledger.fabric_ansible_collection.registered_identity:
+      state: "{{ state }}"
+      api_endpoint: "{{ api_endpoint }}"
+      api_authtype: "{{ api_authtype }}"
+      api_key: "{{ api_key }}"
+      api_secret: "{{ api_secret | default(omit) }}"
+      api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+      api_timeout: "{{ api_timeout | default(omit) }}"
+      certificate_authority: "{{ ca_name }}"
+      registrar: "{{ ca_admin_identity }}"
+      enrollment_id: "{{ peer_enrollment_id }}"
+      enrollment_secret: "{{ peer_enrollment_secret }}"
+      max_enrollments: -1
+      type: peer
 
 - name: Enroll the organization admin
-  hyperledger.fabric-ansible-collection.enrolled_identity:
-    state: "{{ state }}"
-    api_endpoint: "{{ api_endpoint }}"
-    api_authtype: "{{ api_authtype }}"
-    api_key: "{{ api_key }}"
-    api_secret: "{{ api_secret | default(omit) }}"
-    api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-    api_timeout: "{{ api_timeout | default(omit) }}"
-    certificate_authority: "{{ ca_name }}"
-    name: "{{ organization_name }} Admin"
-    enrollment_id: "{{ organization_admin_enrollment_id }}"
-    enrollment_secret: "{{ organization_admin_enrollment_secret }}"
-    path: "{{ organization_admin_identity }}"
+  hyperledger.fabric_ansible_collection.enrolled_identity:
+      state: "{{ state }}"
+      api_endpoint: "{{ api_endpoint }}"
+      api_authtype: "{{ api_authtype }}"
+      api_key: "{{ api_key }}"
+      api_secret: "{{ api_secret | default(omit) }}"
+      api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+      api_timeout: "{{ api_timeout | default(omit) }}"
+      certificate_authority: "{{ ca_name }}"
+      name: "{{ organization_name }} Admin"
+      enrollment_id: "{{ organization_admin_enrollment_id }}"
+      enrollment_secret: "{{ organization_admin_enrollment_secret }}"
+      path: "{{ organization_admin_identity }}"
   register: org_admin
 
 - name: Create organization
-  hyperledger.fabric-ansible-collection.organization:
-    state: "{{ state }}"
-    api_endpoint: "{{ api_endpoint }}"
-    api_authtype: "{{ api_authtype }}"
-    api_key: "{{ api_key }}"
-    api_secret: "{{ api_secret | default(omit) }}"
-    api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-    api_timeout: "{{ api_timeout | default(omit) }}"
-    name: "{{ organization_name }}"
-    msp_id: "{{ organization_msp_id }}"
-    certificate_authority: "{{ ca_name }}"
-    registrar: "{{ ca_admin_identity }}"
-    admins:
-      - "{{ org_admin.enrolled_identity.cert | default(omit) }}"
+  hyperledger.fabric_ansible_collection.organization:
+      state: "{{ state }}"
+      api_endpoint: "{{ api_endpoint }}"
+      api_authtype: "{{ api_authtype }}"
+      api_key: "{{ api_key }}"
+      api_secret: "{{ api_secret | default(omit) }}"
+      api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+      api_timeout: "{{ api_timeout | default(omit) }}"
+      name: "{{ organization_name }}"
+      msp_id: "{{ organization_msp_id }}"
+      certificate_authority: "{{ ca_name }}"
+      registrar: "{{ ca_admin_identity }}"
+      admins:
+          - "{{ org_admin.enrolled_identity.cert | default(omit) }}"
 
 - name: Create peer
-  hyperledger.fabric-ansible-collection.peer:
-    state: "{{ state }}"
-    api_endpoint: "{{ api_endpoint }}"
-    api_authtype: "{{ api_authtype }}"
-    api_key: "{{ api_key }}"
-    api_secret: "{{ api_secret | default(omit) }}"
-    api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-    api_timeout: "{{ api_timeout | default(omit) }}"
-    name: "{{ peer_name }}"
-    msp_id: "{{ organization_msp_id }}"
-    state_db: "{{ peer_state_db }}"
-    certificate_authority: "{{ ca_name }}"
-    enrollment_id: "{{ peer_enrollment_id }}"
-    enrollment_secret: "{{ peer_enrollment_secret }}"
-    admin_certificates:
-      - "{{ org_admin.enrolled_identity.cert | default(omit) }}"
-    resources: "{{ peer_resources | default(omit) }}"
-    storage: "{{ peer_storage | default(omit) }}"
-    version: "{{ peer_version | default(omit) }}"
-    wait_timeout: "{{ wait_timeout | default(omit) }}"
+  hyperledger.fabric_ansible_collection.peer:
+      state: "{{ state }}"
+      api_endpoint: "{{ api_endpoint }}"
+      api_authtype: "{{ api_authtype }}"
+      api_key: "{{ api_key }}"
+      api_secret: "{{ api_secret | default(omit) }}"
+      api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+      api_timeout: "{{ api_timeout | default(omit) }}"
+      name: "{{ peer_name }}"
+      msp_id: "{{ organization_msp_id }}"
+      state_db: "{{ peer_state_db }}"
+      certificate_authority: "{{ ca_name }}"
+      enrollment_id: "{{ peer_enrollment_id }}"
+      enrollment_secret: "{{ peer_enrollment_secret }}"
+      admin_certificates:
+          - "{{ org_admin.enrolled_identity.cert | default(omit) }}"
+      resources: "{{ peer_resources | default(omit) }}"
+      storage: "{{ peer_storage | default(omit) }}"
+      version: "{{ peer_version | default(omit) }}"
+      wait_timeout: "{{ wait_timeout | default(omit) }}"
   when: peers == 1
 
 - name: Create multiple peers
-  hyperledger.fabric-ansible-collection.peer:
-    state: "{{ state }}"
-    api_endpoint: "{{ api_endpoint }}"
-    api_authtype: "{{ api_authtype }}"
-    api_key: "{{ api_key }}"
-    api_secret: "{{ api_secret | default(omit) }}"
-    api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-    api_timeout: "{{ api_timeout | default(omit) }}"
-    name: "{{ peer_name }}{{ item }}"
-    msp_id: "{{ organization_msp_id }}"
-    state_db: "{{ peer_state_db }}"
-    certificate_authority: "{{ ca_name }}"
-    enrollment_id: "{{ peer_enrollment_id }}"
-    enrollment_secret: "{{ peer_enrollment_secret }}"
-    admin_certificates:
-      - "{{ org_admin.enrolled_identity.cert | default(omit) }}"
-    resources: "{{ peer_resources | default(omit) }}"
-    storage: "{{ peer_storage | default(omit) }}"
-    version: "{{ peer_version | default(omit) }}"
-    wait_timeout: "{{ wait_timeout | default(omit) }}"
+  hyperledger.fabric_ansible_collection.peer:
+      state: "{{ state }}"
+      api_endpoint: "{{ api_endpoint }}"
+      api_authtype: "{{ api_authtype }}"
+      api_key: "{{ api_key }}"
+      api_secret: "{{ api_secret | default(omit) }}"
+      api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+      api_timeout: "{{ api_timeout | default(omit) }}"
+      name: "{{ peer_name }}{{ item }}"
+      msp_id: "{{ organization_msp_id }}"
+      state_db: "{{ peer_state_db }}"
+      certificate_authority: "{{ ca_name }}"
+      enrollment_id: "{{ peer_enrollment_id }}"
+      enrollment_secret: "{{ peer_enrollment_secret }}"
+      admin_certificates:
+          - "{{ org_admin.enrolled_identity.cert | default(omit) }}"
+      resources: "{{ peer_resources | default(omit) }}"
+      storage: "{{ peer_storage | default(omit) }}"
+      version: "{{ peer_version | default(omit) }}"
+      wait_timeout: "{{ wait_timeout | default(omit) }}"
   loop: "{{ range(1, peers + 1, 1) | list }}"
   when: peers > 1

--- a/roles/endorsing_organization/tasks/create.yml
+++ b/roles/endorsing_organization/tasks/create.yml
@@ -130,7 +130,7 @@
       enrollment_id: "{{ organization_admin_enrollment_id }}"
       enrollment_secret: "{{ organization_admin_enrollment_secret }}"
       path: "{{ organization_admin_identity }}"
-  register: org_admin
+  register: endorsing_organization_org_admin
 
 - name: Create organization
   hyperledger.fabric_ansible_collection.organization:
@@ -146,7 +146,7 @@
       certificate_authority: "{{ ca_name }}"
       registrar: "{{ ca_admin_identity }}"
       admins:
-          - "{{ org_admin.enrolled_identity.cert | default(omit) }}"
+          - "{{ endorsing_organization_org_admin.enrolled_identity.cert | default(omit) }}"
 
 - name: Create peer
   hyperledger.fabric_ansible_collection.peer:
@@ -164,7 +164,7 @@
       enrollment_id: "{{ peer_enrollment_id }}"
       enrollment_secret: "{{ peer_enrollment_secret }}"
       admin_certificates:
-          - "{{ org_admin.enrolled_identity.cert | default(omit) }}"
+          - "{{ endorsing_organization_org_admin.enrolled_identity.cert | default(omit) }}"
       resources: "{{ peer_resources | default(omit) }}"
       storage: "{{ peer_storage | default(omit) }}"
       version: "{{ peer_version | default(omit) }}"
@@ -187,7 +187,7 @@
       enrollment_id: "{{ peer_enrollment_id }}"
       enrollment_secret: "{{ peer_enrollment_secret }}"
       admin_certificates:
-          - "{{ org_admin.enrolled_identity.cert | default(omit) }}"
+          - "{{ endorsing_organization_org_admin.enrolled_identity.cert | default(omit) }}"
       resources: "{{ peer_resources | default(omit) }}"
       storage: "{{ peer_storage | default(omit) }}"
       version: "{{ peer_version | default(omit) }}"

--- a/roles/endorsing_organization/tasks/delete.yml
+++ b/roles/endorsing_organization/tasks/delete.yml
@@ -3,70 +3,70 @@
 #
 ---
 - name: Delete certificate authority
-  hyperledger.fabric-ansible-collection.certificate_authority:
-    state: "{{ state }}"
-    api_endpoint: "{{ api_endpoint }}"
-    api_authtype: "{{ api_authtype }}"
-    api_key: "{{ api_key }}"
-    api_secret: "{{ api_secret | default(omit) }}"
-    api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-    api_timeout: "{{ api_timeout | default(omit) }}"
-    name: "{{ ca_name }}"
+  hyperledger.fabric_ansible_collection.certificate_authority:
+      state: "{{ state }}"
+      api_endpoint: "{{ api_endpoint }}"
+      api_authtype: "{{ api_authtype }}"
+      api_key: "{{ api_key }}"
+      api_secret: "{{ api_secret | default(omit) }}"
+      api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+      api_timeout: "{{ api_timeout | default(omit) }}"
+      name: "{{ ca_name }}"
 
 - name: Delete certificate authority admin
-  hyperledger.fabric-ansible-collection.enrolled_identity:
-    state: "{{ state }}"
-    api_endpoint: "{{ api_endpoint }}"
-    api_authtype: "{{ api_authtype }}"
-    api_key: "{{ api_key }}"
-    api_secret: "{{ api_secret | default(omit) }}"
-    api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-    api_timeout: "{{ api_timeout | default(omit) }}"
-    path: "{{ ca_admin_identity }}"
+  hyperledger.fabric_ansible_collection.enrolled_identity:
+      state: "{{ state }}"
+      api_endpoint: "{{ api_endpoint }}"
+      api_authtype: "{{ api_authtype }}"
+      api_key: "{{ api_key }}"
+      api_secret: "{{ api_secret | default(omit) }}"
+      api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+      api_timeout: "{{ api_timeout | default(omit) }}"
+      path: "{{ ca_admin_identity }}"
 
 - name: Delete organization admin
-  hyperledger.fabric-ansible-collection.enrolled_identity:
-    state: "{{ state }}"
-    api_endpoint: "{{ api_endpoint }}"
-    api_authtype: "{{ api_authtype }}"
-    api_key: "{{ api_key }}"
-    api_secret: "{{ api_secret | default(omit) }}"
-    api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-    api_timeout: "{{ api_timeout | default(omit) }}"
-    path: "{{ organization_admin_identity }}"
+  hyperledger.fabric_ansible_collection.enrolled_identity:
+      state: "{{ state }}"
+      api_endpoint: "{{ api_endpoint }}"
+      api_authtype: "{{ api_authtype }}"
+      api_key: "{{ api_key }}"
+      api_secret: "{{ api_secret | default(omit) }}"
+      api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+      api_timeout: "{{ api_timeout | default(omit) }}"
+      path: "{{ organization_admin_identity }}"
 
 - name: Delete organization
-  hyperledger.fabric-ansible-collection.organization:
-    state: "{{ state }}"
-    api_endpoint: "{{ api_endpoint }}"
-    api_authtype: "{{ api_authtype }}"
-    api_key: "{{ api_key }}"
-    api_secret: "{{ api_secret | default(omit) }}"
-    api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-    api_timeout: "{{ api_timeout | default(omit) }}"
-    name: "{{ organization_name }}"
+  hyperledger.fabric_ansible_collection.organization:
+      state: "{{ state }}"
+      api_endpoint: "{{ api_endpoint }}"
+      api_authtype: "{{ api_authtype }}"
+      api_key: "{{ api_key }}"
+      api_secret: "{{ api_secret | default(omit) }}"
+      api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+      api_timeout: "{{ api_timeout | default(omit) }}"
+      name: "{{ organization_name }}"
 
 - name: Delete peer
-  hyperledger.fabric-ansible-collection.peer:
-    state: "{{ state }}"
-    api_endpoint: "{{ api_endpoint }}"
-    api_authtype: "{{ api_authtype }}"
-    api_key: "{{ api_key }}"
-    api_secret: "{{ api_secret | default(omit) }}"
-    api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-    api_timeout: "{{ api_timeout | default(omit) }}"
-    name: "{{ peer_name }}"
+  hyperledger.fabric_ansible_collection.peer:
+      state: "{{ state }}"
+      api_endpoint: "{{ api_endpoint }}"
+      api_authtype: "{{ api_authtype }}"
+      api_key: "{{ api_key }}"
+      api_secret: "{{ api_secret | default(omit) }}"
+      api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+      api_timeout: "{{ api_timeout | default(omit) }}"
+      name: "{{ peer_name }}"
   when: peers == 1
 
 - name: Delete multiple peers
-  hyperledger.fabric-ansible-collection.peer:
-    state: "{{ state }}"
-    api_endpoint: "{{ api_endpoint }}"
-    api_authtype: "{{ api_authtype }}"
-    api_key: "{{ api_key }}"
-    api_secret: "{{ api_secret | default(omit) }}"
-    api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-    api_timeout: "{{ api_timeout | default(omit) }}"
-    name: "{{ peer_name }}{{ item }}"
+  hyperledger.fabric_ansible_collection.peer:
+      state: "{{ state }}"
+      api_endpoint: "{{ api_endpoint }}"
+      api_authtype: "{{ api_authtype }}"
+      api_key: "{{ api_key }}"
+      api_secret: "{{ api_secret | default(omit) }}"
+      api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+      api_timeout: "{{ api_timeout | default(omit) }}"
+      name: "{{ peer_name }}{{ item }}"
   loop: "{{ range(1, peers + 1, 1) | list }}"
   when: peers > 1

--- a/roles/fabric_operator_crds/tasks/k8s/create.yml
+++ b/roles/fabric_operator_crds/tasks/k8s/create.yml
@@ -35,7 +35,7 @@
   kubernetes.core.k8s:
     state: present
     namespace: "{{ namespace }}"
-    resource_definition: "{{ lookup('template', 'templates/' + target + '/rbac/'+item) }}"
+    resource_definition: "{{ lookup('template', 'templates/' + target + '/rbac/' + item) }}"
     apply: yes
   loop:
     - hlf-operator-clusterrole.yaml
@@ -46,7 +46,7 @@
   kubernetes.core.k8s:
     state: present
     namespace: "{{ namespace }}"
-    resource_definition: "{{ lookup('template', 'templates/' + target + '/manager/'+item) }}"
+    resource_definition: "{{ lookup('template', 'templates/' + target + '/manager/' + item) }}"
     apply: yes
   loop:
     - hlf-operator-manager.yaml.j2

--- a/roles/fabric_operator_crds/tasks/openshift/create.yml
+++ b/roles/fabric_operator_crds/tasks/openshift/create.yml
@@ -4,7 +4,7 @@
 ---
 - name: Creating CRDs
   kubernetes.core.k8s:
-    definition: "{{ lookup('kubernetes.core.kustomize',dir='https://github.com/hyperledger-labs/fabric-operator.git/config/crd') }}"
+    definition: "{{ lookup('kubernetes.core.kustomize', dir='https://github.com/hyperledger-labs/fabric-operator.git/config/crd') }}"
   register: resultcrds
 
 - name: Fail if project not specified
@@ -42,7 +42,7 @@
   kubernetes.core.k8s:
     state: present
     namespace: "{{ project }}"
-    resource_definition: "{{ lookup('template', 'templates/'+target+'/rbac/'+item) }}"
+    resource_definition: "{{ lookup('template', 'templates/' + target + '/rbac/' + item) }}"
     apply: yes
   loop:
     - hlf-operator-clusterrole.yaml
@@ -53,7 +53,7 @@
   kubernetes.core.k8s:
     state: present
     namespace: "{{ project }}"
-    resource_definition: "{{ lookup('template', 'templates/'+target+'/manager/'+item) }}"
+    resource_definition: "{{ lookup('template', 'templates/' + target + '/manager/' + item) }}"
     apply: yes
   loop:
     - hlf-operator-manager.yaml.j2

--- a/roles/fabric_operator_crds/templates/k8s/ingress/kustomization.yaml
+++ b/roles/fabric_operator_crds/templates/k8s/ingress/kustomization.yaml
@@ -15,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 

--- a/roles/ordering_organization/tasks/create.yml
+++ b/roles/ordering_organization/tasks/create.yml
@@ -130,7 +130,7 @@
       enrollment_id: "{{ organization_admin_enrollment_id }}"
       enrollment_secret: "{{ organization_admin_enrollment_secret }}"
       path: "{{ organization_admin_identity }}"
-  register: org_admin
+  register: ordering_organization_org_admin
 
 - name: Create organization
   hyperledger.fabric_ansible_collection.organization:
@@ -146,7 +146,7 @@
       certificate_authority: "{{ ca_name }}"
       registrar: "{{ ca_admin_identity }}"
       admins:
-          - "{{ org_admin.enrolled_identity.cert | default(omit) }}"
+          - "{{ ordering_organization_org_admin.enrolled_identity.cert | default(omit) }}"
 
 - name: Create ordering service
   hyperledger.fabric_ansible_collection.ordering_service:
@@ -164,7 +164,7 @@
       enrollment_id: "{{ ordering_service_enrollment_id }}"
       enrollment_secret: "{{ ordering_service_enrollment_secret }}"
       admin_certificates:
-          - "{{ org_admin.enrolled_identity.cert | default(omit) }}"
+          - "{{ ordering_organization_org_admin.enrolled_identity.cert | default(omit) }}"
       resources: "{{ ordering_service_resources | default(omit) }}"
       storage: "{{ ordering_service_storage | default(omit) }}"
       version: "{{ ordering_service_version | default(omit) }}"

--- a/roles/ordering_organization/tasks/create.yml
+++ b/roles/ordering_organization/tasks/create.yml
@@ -4,168 +4,168 @@
 ---
 - name: Fail if organization MSP ID not specified
   fail:
-    msg: organization_msp_id not specified or is empty
+      msg: organization_msp_id not specified or is empty
   when: not organization_msp_id is defined or not organization_msp_id
 
 - name: Fail if certificate authority admin enrollment ID not specified
   fail:
-    msg: ca_admin_enrollment_id not specified or is empty
+      msg: ca_admin_enrollment_id not specified or is empty
   when: not ca_admin_enrollment_id is defined or not ca_admin_enrollment_id
 
 - name: Fail if certificate authority admin enrollment secret not specified
   fail:
-    msg: ca_admin_enrollment_secret not specified or is empty
+      msg: ca_admin_enrollment_secret not specified or is empty
   when: not ca_admin_enrollment_secret is defined or not ca_admin_enrollment_secret
 
 - name: Fail if organization admin enrollment ID not specified
   fail:
-    msg: organization_admin_enrollment_id not specified or is empty
+      msg: organization_admin_enrollment_id not specified or is empty
   when: not organization_admin_enrollment_id is defined or not organization_admin_enrollment_id
 
 - name: Fail if organization admin enrollment secret not specified
   fail:
-    msg: organization_admin_enrollment_secret not specified or is empty
+      msg: organization_admin_enrollment_secret not specified or is empty
   when: not organization_admin_enrollment_secret is defined or not organization_admin_enrollment_secret
 
 - name: Fail if ordering service enrollment ID not specified
   fail:
-    msg: ordering_service_enrollment_id not specified or is empty
+      msg: ordering_service_enrollment_id not specified or is empty
   when: not ordering_service_enrollment_id is defined or not ordering_service_enrollment_id
 
 - name: Fail if ordering service enrollment secret not specified
   fail:
-    msg: ordering_service_enrollment_secret not specified or is empty
+      msg: ordering_service_enrollment_secret not specified or is empty
   when: not ordering_service_enrollment_secret is defined or not ordering_service_enrollment_secret
 
 - name: Create certificate authority
-  hyperledger.fabric-ansible-collection.certificate_authority:
-    state: "{{ state }}"
-    api_endpoint: "{{ api_endpoint }}"
-    api_authtype: "{{ api_authtype }}"
-    api_key: "{{ api_key }}"
-    api_secret: "{{ api_secret | default(omit) }}"
-    api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-    api_timeout: "{{ api_timeout | default(omit) }}"
-    name: "{{ ca_name }}"
-    config_override:
-      ca:
-        registry:
-          maxenrollments: -1
-          identities:
-            - name: "{{ ca_admin_enrollment_id }}"
-              pass: "{{ ca_admin_enrollment_secret }}"
-              type: client
-              maxenrollments: -1
-              attrs:
-                hf.Registrar.Roles: "*"
-                hf.Registrar.DelegateRoles: "*"
-                hf.Revoker: true
-                hf.IntermediateCA: true
-                hf.GenCRL: true
-                hf.Registrar.Attributes: "*"
-                hf.AffiliationMgr: true
-    resources: "{{ ca_resources | default(omit) }}"
-    storage: "{{ ca_storage | default(omit) }}"
-    version: "{{ ca_version | default(omit) }}"
-    wait_timeout: "{{ wait_timeout | default(omit) }}"
+  hyperledger.fabric_ansible_collection.certificate_authority:
+      state: "{{ state }}"
+      api_endpoint: "{{ api_endpoint }}"
+      api_authtype: "{{ api_authtype }}"
+      api_key: "{{ api_key }}"
+      api_secret: "{{ api_secret | default(omit) }}"
+      api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+      api_timeout: "{{ api_timeout | default(omit) }}"
+      name: "{{ ca_name }}"
+      config_override:
+          ca:
+              registry:
+                  maxenrollments: -1
+                  identities:
+                      - name: "{{ ca_admin_enrollment_id }}"
+                        pass: "{{ ca_admin_enrollment_secret }}"
+                        type: client
+                        maxenrollments: -1
+                        attrs:
+                            hf.Registrar.Roles: "*"
+                            hf.Registrar.DelegateRoles: "*"
+                            hf.Revoker: true
+                            hf.IntermediateCA: true
+                            hf.GenCRL: true
+                            hf.Registrar.Attributes: "*"
+                            hf.AffiliationMgr: true
+      resources: "{{ ca_resources | default(omit) }}"
+      storage: "{{ ca_storage | default(omit) }}"
+      version: "{{ ca_version | default(omit) }}"
+      wait_timeout: "{{ wait_timeout | default(omit) }}"
 
 - name: Enroll certificate authority admin
-  hyperledger.fabric-ansible-collection.enrolled_identity:
-    state: "{{ state }}"
-    api_endpoint: "{{ api_endpoint }}"
-    api_authtype: "{{ api_authtype }}"
-    api_key: "{{ api_key }}"
-    api_secret: "{{ api_secret | default(omit) }}"
-    api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-    api_timeout: "{{ api_timeout | default(omit) }}"
-    certificate_authority: "{{ ca_name }}"
-    name: "{{ ca_name }} Admin"
-    enrollment_id: "{{ ca_admin_enrollment_id }}"
-    enrollment_secret: "{{ ca_admin_enrollment_secret }}"
-    path: "{{ ca_admin_identity }}"
+  hyperledger.fabric_ansible_collection.enrolled_identity:
+      state: "{{ state }}"
+      api_endpoint: "{{ api_endpoint }}"
+      api_authtype: "{{ api_authtype }}"
+      api_key: "{{ api_key }}"
+      api_secret: "{{ api_secret | default(omit) }}"
+      api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+      api_timeout: "{{ api_timeout | default(omit) }}"
+      certificate_authority: "{{ ca_name }}"
+      name: "{{ ca_name }} Admin"
+      enrollment_id: "{{ ca_admin_enrollment_id }}"
+      enrollment_secret: "{{ ca_admin_enrollment_secret }}"
+      path: "{{ ca_admin_identity }}"
 
 - name: Register the organization admin
-  hyperledger.fabric-ansible-collection.registered_identity:
-    state: "{{ state }}"
-    api_endpoint: "{{ api_endpoint }}"
-    api_authtype: "{{ api_authtype }}"
-    api_key: "{{ api_key }}"
-    api_secret: "{{ api_secret | default(omit) }}"
-    api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-    api_timeout: "{{ api_timeout | default(omit) }}"
-    certificate_authority: "{{ ca_name }}"
-    registrar: "{{ ca_admin_identity }}"
-    enrollment_id: "{{ organization_admin_enrollment_id }}"
-    enrollment_secret: "{{ organization_admin_enrollment_secret }}"
-    max_enrollments: -1
-    type: admin
+  hyperledger.fabric_ansible_collection.registered_identity:
+      state: "{{ state }}"
+      api_endpoint: "{{ api_endpoint }}"
+      api_authtype: "{{ api_authtype }}"
+      api_key: "{{ api_key }}"
+      api_secret: "{{ api_secret | default(omit) }}"
+      api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+      api_timeout: "{{ api_timeout | default(omit) }}"
+      certificate_authority: "{{ ca_name }}"
+      registrar: "{{ ca_admin_identity }}"
+      enrollment_id: "{{ organization_admin_enrollment_id }}"
+      enrollment_secret: "{{ organization_admin_enrollment_secret }}"
+      max_enrollments: -1
+      type: admin
 
 - name: Register the ordering service
-  hyperledger.fabric-ansible-collection.registered_identity:
-    state: "{{ state }}"
-    api_endpoint: "{{ api_endpoint }}"
-    api_authtype: "{{ api_authtype }}"
-    api_key: "{{ api_key }}"
-    api_secret: "{{ api_secret | default(omit) }}"
-    api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-    api_timeout: "{{ api_timeout | default(omit) }}"
-    certificate_authority: "{{ ca_name }}"
-    registrar: "{{ ca_admin_identity }}"
-    enrollment_id: "{{ ordering_service_enrollment_id }}"
-    enrollment_secret: "{{ ordering_service_enrollment_secret }}"
-    max_enrollments: -1
-    type: orderer
+  hyperledger.fabric_ansible_collection.registered_identity:
+      state: "{{ state }}"
+      api_endpoint: "{{ api_endpoint }}"
+      api_authtype: "{{ api_authtype }}"
+      api_key: "{{ api_key }}"
+      api_secret: "{{ api_secret | default(omit) }}"
+      api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+      api_timeout: "{{ api_timeout | default(omit) }}"
+      certificate_authority: "{{ ca_name }}"
+      registrar: "{{ ca_admin_identity }}"
+      enrollment_id: "{{ ordering_service_enrollment_id }}"
+      enrollment_secret: "{{ ordering_service_enrollment_secret }}"
+      max_enrollments: -1
+      type: orderer
 
 - name: Enroll the organization admin
-  hyperledger.fabric-ansible-collection.enrolled_identity:
-    state: "{{ state }}"
-    api_endpoint: "{{ api_endpoint }}"
-    api_authtype: "{{ api_authtype }}"
-    api_key: "{{ api_key }}"
-    api_secret: "{{ api_secret | default(omit) }}"
-    api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-    api_timeout: "{{ api_timeout | default(omit) }}"
-    certificate_authority: "{{ ca_name }}"
-    name: "{{ organization_name }} Admin"
-    enrollment_id: "{{ organization_admin_enrollment_id }}"
-    enrollment_secret: "{{ organization_admin_enrollment_secret }}"
-    path: "{{ organization_admin_identity }}"
+  hyperledger.fabric_ansible_collection.enrolled_identity:
+      state: "{{ state }}"
+      api_endpoint: "{{ api_endpoint }}"
+      api_authtype: "{{ api_authtype }}"
+      api_key: "{{ api_key }}"
+      api_secret: "{{ api_secret | default(omit) }}"
+      api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+      api_timeout: "{{ api_timeout | default(omit) }}"
+      certificate_authority: "{{ ca_name }}"
+      name: "{{ organization_name }} Admin"
+      enrollment_id: "{{ organization_admin_enrollment_id }}"
+      enrollment_secret: "{{ organization_admin_enrollment_secret }}"
+      path: "{{ organization_admin_identity }}"
   register: org_admin
 
 - name: Create organization
-  hyperledger.fabric-ansible-collection.organization:
-    state: "{{ state }}"
-    api_endpoint: "{{ api_endpoint }}"
-    api_authtype: "{{ api_authtype }}"
-    api_key: "{{ api_key }}"
-    api_secret: "{{ api_secret | default(omit) }}"
-    api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-    api_timeout: "{{ api_timeout | default(omit) }}"
-    name: "{{ organization_name }}"
-    msp_id: "{{ organization_msp_id }}"
-    certificate_authority: "{{ ca_name }}"
-    registrar: "{{ ca_admin_identity }}"
-    admins:
-      - "{{ org_admin.enrolled_identity.cert | default(omit) }}"
+  hyperledger.fabric_ansible_collection.organization:
+      state: "{{ state }}"
+      api_endpoint: "{{ api_endpoint }}"
+      api_authtype: "{{ api_authtype }}"
+      api_key: "{{ api_key }}"
+      api_secret: "{{ api_secret | default(omit) }}"
+      api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+      api_timeout: "{{ api_timeout | default(omit) }}"
+      name: "{{ organization_name }}"
+      msp_id: "{{ organization_msp_id }}"
+      certificate_authority: "{{ ca_name }}"
+      registrar: "{{ ca_admin_identity }}"
+      admins:
+          - "{{ org_admin.enrolled_identity.cert | default(omit) }}"
 
 - name: Create ordering service
-  hyperledger.fabric-ansible-collection.ordering_service:
-    state: "{{ state }}"
-    api_endpoint: "{{ api_endpoint }}"
-    api_authtype: "{{ api_authtype }}"
-    api_key: "{{ api_key }}"
-    api_secret: "{{ api_secret | default(omit) }}"
-    api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-    api_timeout: "{{ api_timeout | default(omit) }}"
-    name: "{{ ordering_service_name }}"
-    msp_id: "{{ organization_msp_id }}"
-    nodes: "{{ ordering_service_nodes }}"
-    certificate_authority: "{{ ca_name }}"
-    enrollment_id: "{{ ordering_service_enrollment_id }}"
-    enrollment_secret: "{{ ordering_service_enrollment_secret }}"
-    admin_certificates:
-      - "{{ org_admin.enrolled_identity.cert | default(omit) }}"
-    resources: "{{ ordering_service_resources | default(omit) }}"
-    storage: "{{ ordering_service_storage | default(omit) }}"
-    version: "{{ ordering_service_version | default(omit) }}"
-    wait_timeout: "{{ wait_timeout | default(omit) }}"
+  hyperledger.fabric_ansible_collection.ordering_service:
+      state: "{{ state }}"
+      api_endpoint: "{{ api_endpoint }}"
+      api_authtype: "{{ api_authtype }}"
+      api_key: "{{ api_key }}"
+      api_secret: "{{ api_secret | default(omit) }}"
+      api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+      api_timeout: "{{ api_timeout | default(omit) }}"
+      name: "{{ ordering_service_name }}"
+      msp_id: "{{ organization_msp_id }}"
+      nodes: "{{ ordering_service_nodes }}"
+      certificate_authority: "{{ ca_name }}"
+      enrollment_id: "{{ ordering_service_enrollment_id }}"
+      enrollment_secret: "{{ ordering_service_enrollment_secret }}"
+      admin_certificates:
+          - "{{ org_admin.enrolled_identity.cert | default(omit) }}"
+      resources: "{{ ordering_service_resources | default(omit) }}"
+      storage: "{{ ordering_service_storage | default(omit) }}"
+      version: "{{ ordering_service_version | default(omit) }}"
+      wait_timeout: "{{ wait_timeout | default(omit) }}"

--- a/roles/ordering_organization/tasks/delete.yml
+++ b/roles/ordering_organization/tasks/delete.yml
@@ -3,56 +3,56 @@
 #
 ---
 - name: Delete certificate authority
-  hyperledger.fabric-ansible-collection.certificate_authority:
-    state: "{{ state }}"
-    api_endpoint: "{{ api_endpoint }}"
-    api_authtype: "{{ api_authtype }}"
-    api_key: "{{ api_key }}"
-    api_secret: "{{ api_secret | default(omit) }}"
-    api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-    api_timeout: "{{ api_timeout | default(omit) }}"
-    name: "{{ ca_name }}"
+  hyperledger.fabric_ansible_collection.certificate_authority:
+      state: "{{ state }}"
+      api_endpoint: "{{ api_endpoint }}"
+      api_authtype: "{{ api_authtype }}"
+      api_key: "{{ api_key }}"
+      api_secret: "{{ api_secret | default(omit) }}"
+      api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+      api_timeout: "{{ api_timeout | default(omit) }}"
+      name: "{{ ca_name }}"
 
 - name: Delete certificate authority admin
-  hyperledger.fabric-ansible-collection.enrolled_identity:
-    state: "{{ state }}"
-    api_endpoint: "{{ api_endpoint }}"
-    api_authtype: "{{ api_authtype }}"
-    api_key: "{{ api_key }}"
-    api_secret: "{{ api_secret | default(omit) }}"
-    api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-    api_timeout: "{{ api_timeout | default(omit) }}"
-    path: "{{ ca_admin_identity }}"
+  hyperledger.fabric_ansible_collection.enrolled_identity:
+      state: "{{ state }}"
+      api_endpoint: "{{ api_endpoint }}"
+      api_authtype: "{{ api_authtype }}"
+      api_key: "{{ api_key }}"
+      api_secret: "{{ api_secret | default(omit) }}"
+      api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+      api_timeout: "{{ api_timeout | default(omit) }}"
+      path: "{{ ca_admin_identity }}"
 
 - name: Delete organization admin
-  hyperledger.fabric-ansible-collection.enrolled_identity:
-    state: "{{ state }}"
-    api_endpoint: "{{ api_endpoint }}"
-    api_authtype: "{{ api_authtype }}"
-    api_key: "{{ api_key }}"
-    api_secret: "{{ api_secret | default(omit) }}"
-    api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-    api_timeout: "{{ api_timeout | default(omit) }}"
-    path: "{{ organization_admin_identity }}"
+  hyperledger.fabric_ansible_collection.enrolled_identity:
+      state: "{{ state }}"
+      api_endpoint: "{{ api_endpoint }}"
+      api_authtype: "{{ api_authtype }}"
+      api_key: "{{ api_key }}"
+      api_secret: "{{ api_secret | default(omit) }}"
+      api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+      api_timeout: "{{ api_timeout | default(omit) }}"
+      path: "{{ organization_admin_identity }}"
 
 - name: Delete organization
-  hyperledger.fabric-ansible-collection.organization:
-    state: "{{ state }}"
-    api_endpoint: "{{ api_endpoint }}"
-    api_authtype: "{{ api_authtype }}"
-    api_key: "{{ api_key }}"
-    api_secret: "{{ api_secret | default(omit) }}"
-    api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-    api_timeout: "{{ api_timeout | default(omit) }}"
-    name: "{{ organization_name }}"
+  hyperledger.fabric_ansible_collection.organization:
+      state: "{{ state }}"
+      api_endpoint: "{{ api_endpoint }}"
+      api_authtype: "{{ api_authtype }}"
+      api_key: "{{ api_key }}"
+      api_secret: "{{ api_secret | default(omit) }}"
+      api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+      api_timeout: "{{ api_timeout | default(omit) }}"
+      name: "{{ organization_name }}"
 
 - name: Delete ordering service
-  hyperledger.fabric-ansible-collection.ordering_service:
-    state: "{{ state }}"
-    api_endpoint: "{{ api_endpoint }}"
-    api_authtype: "{{ api_authtype }}"
-    api_key: "{{ api_key }}"
-    api_secret: "{{ api_secret | default(omit) }}"
-    api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-    api_timeout: "{{ api_timeout | default(omit) }}"
-    name: "{{ ordering_service_name }}"
+  hyperledger.fabric_ansible_collection.ordering_service:
+      state: "{{ state }}"
+      api_endpoint: "{{ api_endpoint }}"
+      api_authtype: "{{ api_authtype }}"
+      api_key: "{{ api_key }}"
+      api_secret: "{{ api_secret | default(omit) }}"
+      api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+      api_timeout: "{{ api_timeout | default(omit) }}"
+      name: "{{ ordering_service_name }}"

--- a/tutorial/01-create-ordering-organization-components.yml
+++ b/tutorial/01-create-ordering-organization-components.yml
@@ -5,11 +5,11 @@
 - name: Create components for an ordering organization
   hosts: localhost
   vars:
-    state: present
-    organization_name: "{{ ordering_org_name }}"
-    organization_msp_id: "{{ ordering_service_msp }}"
+      state: present
+      organization_name: "{{ ordering_org_name }}"
+      organization_msp_id: "{{ ordering_service_msp }}"
   vars_files:
-    - common-vars.yml
-    - ordering-org-vars.yml
+      - common-vars.yml
+      - ordering-org-vars.yml
   roles:
-    - hyperledger.fabric-ansible-collection.ordering_organization
+      - hyperledger.fabric_ansible_collection.ordering_organization

--- a/tutorial/02-create-endorsing-organization-components.yml
+++ b/tutorial/02-create-endorsing-organization-components.yml
@@ -5,13 +5,13 @@
 - name: Create components for an endorsing organization
   hosts: localhost
   vars:
-    state: present
-    organization_name: "{{ org1_name }}"
-    organization_msp_id: "{{ org1_msp_id }}"
-    ca_name: "{{ org1_ca_name }}"
-    peer_name: "{{ org1_peer_name }}"
+      state: present
+      organization_name: "{{ org1_name }}"
+      organization_msp_id: "{{ org1_msp_id }}"
+      ca_name: "{{ org1_ca_name }}"
+      peer_name: "{{ org1_peer_name }}"
   vars_files:
-    - common-vars.yml
-    - org1-vars.yml
+      - common-vars.yml
+      - org1-vars.yml
   roles:
-    - hyperledger.fabric-ansible-collection.endorsing_organization
+      - hyperledger.fabric_ansible_collection.endorsing_organization

--- a/tutorial/03-export-organization.yml
+++ b/tutorial/03-export-organization.yml
@@ -5,25 +5,25 @@
 - name: Export the organization
   hosts: localhost
   vars_files:
-    - common-vars.yml
-    - org1-vars.yml
+      - common-vars.yml
+      - org1-vars.yml
   tasks:
-    - name: Get the organization
-      hyperledger.fabric-ansible-collection.organization_info:
-        api_endpoint: "{{ api_endpoint }}"
-        api_authtype: "{{ api_authtype }}"
-        api_key: "{{ api_key }}"
-        api_secret: "{{ api_secret | default(omit) }}"
-        api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-        name: "{{ org1_name }}"
-      register: result
+      - name: Get the organization
+        hyperledger.fabric_ansible_collection.organization_info:
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+            name: "{{ org1_name }}"
+        register: result
 
-    - name: Fail if the organization does not exist
-      fail:
-        msg: "Organization {{ org1_name }} does not exist"
-      when: not result.exists
+      - name: Fail if the organization does not exist
+        fail:
+            msg: "Organization {{ org1_name }} does not exist"
+        when: not result.exists
 
-    - name: Store the organization in a file
-      copy:
-        content: "{{ result.organization | to_nice_json }}"
-        dest: "{{ org1_name }}.json"
+      - name: Store the organization in a file
+        copy:
+            content: "{{ result.organization | to_nice_json }}"
+            dest: "{{ org1_name }}.json"

--- a/tutorial/04-import-organization.yml
+++ b/tutorial/04-import-organization.yml
@@ -5,14 +5,14 @@
 - name: Import the organization
   hosts: localhost
   vars_files:
-    - common-vars.yml
-    - ordering-org-vars.yml
+      - common-vars.yml
+      - ordering-org-vars.yml
   tasks:
-    - name: Import the organization
-      hyperledger.fabric-ansible-collection.external_organization:
-        api_endpoint: "{{ api_endpoint }}"
-        api_authtype: "{{ api_authtype }}"
-        api_key: "{{ api_key }}"
-        api_secret: "{{ api_secret | default(omit) }}"
-        api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-        organization: "{{ lookup('file', org1_name+'.json') }}"
+      - name: Import the organization
+        hyperledger.fabric_ansible_collection.external_organization:
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+            organization: "{{ lookup('file', org1_name+'.json') }}"

--- a/tutorial/05-enable-capabilities.yml
+++ b/tutorial/05-enable-capabilities.yml
@@ -5,78 +5,78 @@
 - name: Enable Fabric v2.x capabilities
   hosts: localhost
   vars_files:
-    - common-vars.yml
-    - ordering-org-vars.yml
+      - common-vars.yml
+      - ordering-org-vars.yml
   tasks:
-    - name: Get the ordering service information
-      hyperledger.fabric-ansible-collection.ordering_service_info:
-        api_endpoint: "{{ api_endpoint }}"
-        api_authtype: "{{ api_authtype }}"
-        api_key: "{{ api_key }}"
-        api_secret: "{{ api_secret | default(omit) }}"
-        api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-        name: "{{ ordering_service_name }}"
-      register: ordering_service
+      - name: Get the ordering service information
+        hyperledger.fabric_ansible_collection.ordering_service_info:
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+            name: "{{ ordering_service_name }}"
+        register: ordering_service
 
-    - name: Fail if the ordering service does not exist
-      fail:
-        msg: "{{ ordering_service_name }} does not exist"
-      when: not ordering_service.exists
+      - name: Fail if the ordering service does not exist
+        fail:
+            msg: "{{ ordering_service_name }} does not exist"
+        when: not ordering_service.exists
 
-    - name: Fetch the system channel configuration
-      hyperledger.fabric-ansible-collection.channel_config:
-        api_endpoint: "{{ api_endpoint }}"
-        api_authtype: "{{ api_authtype }}"
-        api_key: "{{ api_key }}"
-        api_secret: "{{ api_secret | default(omit) }}"
-        api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-        ordering_service: "{{ ordering_service_name }}"
-        identity: "{{ ordering_org_name }} Admin.json"
-        msp_id: "{{ ordering_service_msp }}"
-        operation: fetch
-        name: "{{ ordering_service.ordering_service[0].system_channel_id }}"
-        path: original_config.bin
+      - name: Fetch the system channel configuration
+        hyperledger.fabric_ansible_collection.channel_config:
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+            ordering_service: "{{ ordering_service_name }}"
+            identity: "{{ ordering_org_name }} Admin.json"
+            msp_id: "{{ ordering_service_msp }}"
+            operation: fetch
+            name: "{{ ordering_service.ordering_service[0].system_channel_id }}"
+            path: original_config.bin
 
-    - name: Create a copy of the system channel configuration
-      copy:
-        src: original_config.bin
-        dest: updated_config.bin
+      - name: Create a copy of the system channel configuration
+        copy:
+            src: original_config.bin
+            dest: updated_config.bin
 
-    - name: Enable Fabric v2.x capabilities
-      hyperledger.fabric-ansible-collection.channel_capabilities:
-        path: updated_config.bin
-        channel: V2_0
-        orderer: V2_0
+      - name: Enable Fabric v2.x capabilities
+        hyperledger.fabric_ansible_collection.channel_capabilities:
+            path: updated_config.bin
+            channel: V2_0
+            orderer: V2_0
 
-    - name: Compute the system channel configuration update
-      hyperledger.fabric-ansible-collection.channel_config:
-        operation: compute_update
-        name: "{{ ordering_service.ordering_service[0].system_channel_id }}"
-        original: original_config.bin
-        updated: updated_config.bin
-        path: config_update.bin
-      register: compute_update
+      - name: Compute the system channel configuration update
+        hyperledger.fabric_ansible_collection.channel_config:
+            operation: compute_update
+            name: "{{ ordering_service.ordering_service[0].system_channel_id }}"
+            original: original_config.bin
+            updated: updated_config.bin
+            path: config_update.bin
+        register: compute_update
 
-    - name: Sign the system channel configuration update
-      hyperledger.fabric-ansible-collection.channel_config:
-        operation: sign_update
-        identity: "{{ ordering_org_name }} Admin.json"
-        msp_id: "{{ ordering_service_msp }}"
-        name: "{{ ordering_service.ordering_service[0].system_channel_id }}"
-        path: config_update.bin
-      when: compute_update.path
+      - name: Sign the system channel configuration update
+        hyperledger.fabric_ansible_collection.channel_config:
+            operation: sign_update
+            identity: "{{ ordering_org_name }} Admin.json"
+            msp_id: "{{ ordering_service_msp }}"
+            name: "{{ ordering_service.ordering_service[0].system_channel_id }}"
+            path: config_update.bin
+        when: compute_update.path
 
-    - name: Apply the system channel configuration update
-      hyperledger.fabric-ansible-collection.channel_config:
-        api_endpoint: "{{ api_endpoint }}"
-        api_authtype: "{{ api_authtype }}"
-        api_key: "{{ api_key }}"
-        api_secret: "{{ api_secret | default(omit) }}"
-        api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-        operation: apply_update
-        ordering_service: "{{ ordering_service_name }}"
-        identity: "{{ ordering_org_name }} Admin.json"
-        msp_id: "{{ ordering_service_msp }}"
-        name: "{{ ordering_service.ordering_service[0].system_channel_id }}"
-        path: config_update.bin
-      when: compute_update.path
+      - name: Apply the system channel configuration update
+        hyperledger.fabric_ansible_collection.channel_config:
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+            operation: apply_update
+            ordering_service: "{{ ordering_service_name }}"
+            identity: "{{ ordering_org_name }} Admin.json"
+            msp_id: "{{ ordering_service_msp }}"
+            name: "{{ ordering_service.ordering_service[0].system_channel_id }}"
+            path: config_update.bin
+        when: compute_update.path

--- a/tutorial/06-add-organization-to-consortium.yml
+++ b/tutorial/06-add-organization-to-consortium.yml
@@ -5,83 +5,83 @@
 - name: Add the organization to the consortium
   hosts: localhost
   vars_files:
-    - common-vars.yml
-    - ordering-org-vars.yml
+      - common-vars.yml
+      - ordering-org-vars.yml
   tasks:
-    - name: Get the ordering service information
-      hyperledger.fabric-ansible-collection.ordering_service_info:
-        api_endpoint: "{{ api_endpoint }}"
-        api_authtype: "{{ api_authtype }}"
-        api_key: "{{ api_key }}"
-        api_secret: "{{ api_secret | default(omit) }}"
-        api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-        name: "{{ ordering_service_name }}"
-      register: ordering_service
+      - name: Get the ordering service information
+        hyperledger.fabric_ansible_collection.ordering_service_info:
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+            name: "{{ ordering_service_name }}"
+        register: ordering_service
 
-    - name: Fail if the ordering service does not exist
-      fail:
-        msg: "{{ ordering_service_name }} does not exist"
-      when: not ordering_service.exists
+      - name: Fail if the ordering service does not exist
+        fail:
+            msg: "{{ ordering_service_name }} does not exist"
+        when: not ordering_service.exists
 
-    - name: Fetch the system channel configuration
-      hyperledger.fabric-ansible-collection.channel_config:
-        api_endpoint: "{{ api_endpoint }}"
-        api_authtype: "{{ api_authtype }}"
-        api_key: "{{ api_key }}"
-        api_secret: "{{ api_secret | default(omit) }}"
-        api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-        ordering_service: "{{ ordering_service_name }}"
-        identity: "{{ ordering_org_name }} Admin.json"
-        msp_id: "{{ ordering_service_msp }}"
-        operation: fetch
-        name: "{{ ordering_service.ordering_service[0].system_channel_id }}"
-        path: original_config.bin
+      - name: Fetch the system channel configuration
+        hyperledger.fabric_ansible_collection.channel_config:
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+            ordering_service: "{{ ordering_service_name }}"
+            identity: "{{ ordering_org_name }} Admin.json"
+            msp_id: "{{ ordering_service_msp }}"
+            operation: fetch
+            name: "{{ ordering_service.ordering_service[0].system_channel_id }}"
+            path: original_config.bin
 
-    - name: Create a copy of the system channel configuration
-      copy:
-        src: original_config.bin
-        dest: updated_config.bin
+      - name: Create a copy of the system channel configuration
+        copy:
+            src: original_config.bin
+            dest: updated_config.bin
 
-    - name: Add the organization to the consortium
-      hyperledger.fabric-ansible-collection.consortium_member:
-        state: present
-        api_endpoint: "{{ api_endpoint }}"
-        api_authtype: "{{ api_authtype }}"
-        api_key: "{{ api_key }}"
-        api_secret: "{{ api_secret | default(omit) }}"
-        api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-        organization: "{{ org1_name }}"
-        path: updated_config.bin
+      - name: Add the organization to the consortium
+        hyperledger.fabric_ansible_collection.consortium_member:
+            state: present
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+            organization: "{{ org1_name }}"
+            path: updated_config.bin
 
-    - name: Compute the system channel configuration update
-      hyperledger.fabric-ansible-collection.channel_config:
-        operation: compute_update
-        name: "{{ ordering_service.ordering_service[0].system_channel_id }}"
-        original: original_config.bin
-        updated: updated_config.bin
-        path: config_update.bin
-      register: compute_update
+      - name: Compute the system channel configuration update
+        hyperledger.fabric_ansible_collection.channel_config:
+            operation: compute_update
+            name: "{{ ordering_service.ordering_service[0].system_channel_id }}"
+            original: original_config.bin
+            updated: updated_config.bin
+            path: config_update.bin
+        register: compute_update
 
-    - name: Sign the system channel configuration update
-      hyperledger.fabric-ansible-collection.channel_config:
-        operation: sign_update
-        identity: "{{ ordering_org_name }} Admin.json"
-        msp_id: "{{ ordering_service_msp }}"
-        name: "{{ ordering_service.ordering_service[0].system_channel_id }}"
-        path: config_update.bin
-      when: compute_update.path
+      - name: Sign the system channel configuration update
+        hyperledger.fabric_ansible_collection.channel_config:
+            operation: sign_update
+            identity: "{{ ordering_org_name }} Admin.json"
+            msp_id: "{{ ordering_service_msp }}"
+            name: "{{ ordering_service.ordering_service[0].system_channel_id }}"
+            path: config_update.bin
+        when: compute_update.path
 
-    - name: Apply the system channel configuration update
-      hyperledger.fabric-ansible-collection.channel_config:
-        api_endpoint: "{{ api_endpoint }}"
-        api_authtype: "{{ api_authtype }}"
-        api_key: "{{ api_key }}"
-        api_secret: "{{ api_secret | default(omit) }}"
-        api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-        operation: apply_update
-        ordering_service: "{{ ordering_service_name }}"
-        identity: "{{ ordering_org_name }} Admin.json"
-        msp_id: "{{ ordering_service_msp }}"
-        name: "{{ ordering_service.ordering_service[0].system_channel_id }}"
-        path: config_update.bin
-      when: compute_update.path
+      - name: Apply the system channel configuration update
+        hyperledger.fabric_ansible_collection.channel_config:
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+            operation: apply_update
+            ordering_service: "{{ ordering_service_name }}"
+            identity: "{{ ordering_org_name }} Admin.json"
+            msp_id: "{{ ordering_service_msp }}"
+            name: "{{ ordering_service.ordering_service[0].system_channel_id }}"
+            path: config_update.bin
+        when: compute_update.path

--- a/tutorial/07-export-ordering-service.yml
+++ b/tutorial/07-export-ordering-service.yml
@@ -5,25 +5,25 @@
 - name: Export the ordering service
   hosts: localhost
   vars_files:
-    - common-vars.yml
-    - ordering-org-vars.yml
+      - common-vars.yml
+      - ordering-org-vars.yml
   tasks:
-    - name: Get the ordering service
-      hyperledger.fabric-ansible-collection.ordering_service_info:
-        api_endpoint: "{{ api_endpoint }}"
-        api_authtype: "{{ api_authtype }}"
-        api_key: "{{ api_key }}"
-        api_secret: "{{ api_secret | default(omit) }}"
-        api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-        name: "{{ ordering_service_name }}"
-      register: result
+      - name: Get the ordering service
+        hyperledger.fabric_ansible_collection.ordering_service_info:
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+            name: "{{ ordering_service_name }}"
+        register: result
 
-    - name: Fail if the ordering service does not exist
-      fail:
-        msg: Ordering service does not exist
-      when: not result.exists
+      - name: Fail if the ordering service does not exist
+        fail:
+            msg: Ordering service does not exist
+        when: not result.exists
 
-    - name: Store the ordering service in a file
-      copy:
-        content: "{{ result.ordering_service | to_nice_json }}"
-        dest: "{{ ordering_service_name }}.json"
+      - name: Store the ordering service in a file
+        copy:
+            content: "{{ result.ordering_service | to_nice_json }}"
+            dest: "{{ ordering_service_name }}.json"

--- a/tutorial/08-import-ordering-service.yml
+++ b/tutorial/08-import-ordering-service.yml
@@ -5,14 +5,14 @@
 - name: Import the ordering service
   hosts: localhost
   vars_files:
-    - common-vars.yml
-    - org1-vars.yml
+      - common-vars.yml
+      - org1-vars.yml
   tasks:
-    - name: Import the ordering service
-      hyperledger.fabric-ansible-collection.external_ordering_service:
-        api_endpoint: "{{ api_endpoint }}"
-        api_authtype: "{{ api_authtype }}"
-        api_key: "{{ api_key }}"
-        api_secret: "{{ api_secret | default(omit) }}"
-        api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-        ordering_service: "{{ lookup('file', ordering_service_name+'.json') }}"
+      - name: Import the ordering service
+        hyperledger.fabric_ansible_collection.external_ordering_service:
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+            ordering_service: "{{ lookup('file', ordering_service_name+'.json') }}"

--- a/tutorial/09-create-channel.yml
+++ b/tutorial/09-create-channel.yml
@@ -5,73 +5,73 @@
 - name: Create the channel
   hosts: localhost
   vars_files:
-    - common-vars.yml
-    - org1-vars.yml
+      - common-vars.yml
+      - org1-vars.yml
   tasks:
-    - name: Check to see if the channel already exists
-      hyperledger.fabric-ansible-collection.channel_block:
-        api_endpoint: "{{ api_endpoint }}"
-        api_authtype: "{{ api_authtype }}"
-        api_key: "{{ api_key }}"
-        api_secret: "{{ api_secret | default(omit) }}"
-        api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-        operation: fetch
-        ordering_service: "{{ ordering_service_name }}"
-        identity: "{{ org1_name }} Admin.json"
-        msp_id: "{{ org1_msp_id }}"
-        name: "{{ channel_name }}"
-        target: "0"
-        path: channel_genesis_block.bin
-      failed_when: False
-      register: result
+      - name: Check to see if the channel already exists
+        hyperledger.fabric_ansible_collection.channel_block:
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+            operation: fetch
+            ordering_service: "{{ ordering_service_name }}"
+            identity: "{{ org1_name }} Admin.json"
+            msp_id: "{{ org1_msp_id }}"
+            name: "{{ channel_name }}"
+            target: "0"
+            path: channel_genesis_block.bin
+        failed_when: False
+        register: result
 
-    - name: Fail on any error other than the channel not existing
-      fail:
-        msg: "{{ result.msg }}"
-      when: result.msg is defined and 'NOT_FOUND' not in result.msg
+      - name: Fail on any error other than the channel not existing
+        fail:
+            msg: "{{ result.msg }}"
+        when: result.msg is defined and 'NOT_FOUND' not in result.msg
 
-    - name: Create the configuration update for the new channel
-      hyperledger.fabric-ansible-collection.channel_config:
-        api_endpoint: "{{ api_endpoint }}"
-        api_authtype: "{{ api_authtype }}"
-        api_key: "{{ api_key }}"
-        api_secret: "{{ api_secret | default(omit) }}"
-        api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-        operation: create
-        name: "{{ channel_name }}"
-        path: config_update.bin
-        organizations:
-          - "{{ org1_name }}"
-        policies:
-          Admins: "{{ lookup('template', '09-admins-policy.json.j2') }}"
-          Readers: "{{ lookup('template', '09-readers-policy.json.j2') }}"
-          Writers: "{{ lookup('template', '09-writers-policy.json.j2') }}"
-          Endorsement: "{{ lookup('template', '09-endorsement-policy.json.j2') }}"
-          LifecycleEndorsement: "{{ lookup('template', '09-lifecycle-endorsement-policy.json.j2') }}"
-        capabilities:
-          application: V2_0
-      when: result.msg is defined and 'NOT_FOUND' in result.msg
+      - name: Create the configuration update for the new channel
+        hyperledger.fabric_ansible_collection.channel_config:
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+            operation: create
+            name: "{{ channel_name }}"
+            path: config_update.bin
+            organizations:
+                - "{{ org1_name }}"
+            policies:
+                Admins: "{{ lookup('template', '09-admins-policy.json.j2') }}"
+                Readers: "{{ lookup('template', '09-readers-policy.json.j2') }}"
+                Writers: "{{ lookup('template', '09-writers-policy.json.j2') }}"
+                Endorsement: "{{ lookup('template', '09-endorsement-policy.json.j2') }}"
+                LifecycleEndorsement: "{{ lookup('template', '09-lifecycle-endorsement-policy.json.j2') }}"
+            capabilities:
+                application: V2_0
+        when: result.msg is defined and 'NOT_FOUND' in result.msg
 
-    - name: Sign the channel configuration update for the new channel
-      hyperledger.fabric-ansible-collection.channel_config:
-        operation: sign_update
-        identity: "{{ org1_name }} Admin.json"
-        msp_id: "{{ org1_msp_id }}"
-        name: "{{ channel_name }}"
-        path: config_update.bin
-      when: result.msg is defined and 'NOT_FOUND' in result.msg
+      - name: Sign the channel configuration update for the new channel
+        hyperledger.fabric_ansible_collection.channel_config:
+            operation: sign_update
+            identity: "{{ org1_name }} Admin.json"
+            msp_id: "{{ org1_msp_id }}"
+            name: "{{ channel_name }}"
+            path: config_update.bin
+        when: result.msg is defined and 'NOT_FOUND' in result.msg
 
-    - name: Apply the channel configuration update for the new channel
-      hyperledger.fabric-ansible-collection.channel_config:
-        api_endpoint: "{{ api_endpoint }}"
-        api_authtype: "{{ api_authtype }}"
-        api_key: "{{ api_key }}"
-        api_secret: "{{ api_secret | default(omit) }}"
-        api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-        operation: apply_update
-        ordering_service: "{{ ordering_service_name }}"
-        identity: "{{ org1_name }} Admin.json"
-        msp_id: "{{ org1_msp_id }}"
-        name: "{{ channel_name }}"
-        path: config_update.bin
-      when: result.msg is defined and 'NOT_FOUND' in result.msg
+      - name: Apply the channel configuration update for the new channel
+        hyperledger.fabric_ansible_collection.channel_config:
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+            operation: apply_update
+            ordering_service: "{{ ordering_service_name }}"
+            identity: "{{ org1_name }} Admin.json"
+            msp_id: "{{ org1_msp_id }}"
+            name: "{{ channel_name }}"
+            path: config_update.bin
+        when: result.msg is defined and 'NOT_FOUND' in result.msg

--- a/tutorial/10-join-peer-to-channel.yml
+++ b/tutorial/10-join-peer-to-channel.yml
@@ -5,33 +5,33 @@
 - name: Join the channel
   hosts: localhost
   vars_files:
-    - common-vars.yml
-    - org1-vars.yml
+      - common-vars.yml
+      - org1-vars.yml
   tasks:
-    - name: Fetch the genesis block for the channel
-      hyperledger.fabric-ansible-collection.channel_block:
-        api_endpoint: "{{ api_endpoint }}"
-        api_authtype: "{{ api_authtype }}"
-        api_key: "{{ api_key }}"
-        api_secret: "{{ api_secret | default(omit) }}"
-        api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-        operation: fetch
-        ordering_service: "{{ ordering_service_name }}"
-        identity: "{{ org1_name }} Admin.json"
-        msp_id: "{{ org1_msp_id }}"
-        name: "{{ channel_name }}"
-        target: "0"
-        path: channel_genesis_block.bin
+      - name: Fetch the genesis block for the channel
+        hyperledger.fabric_ansible_collection.channel_block:
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+            operation: fetch
+            ordering_service: "{{ ordering_service_name }}"
+            identity: "{{ org1_name }} Admin.json"
+            msp_id: "{{ org1_msp_id }}"
+            name: "{{ channel_name }}"
+            target: "0"
+            path: channel_genesis_block.bin
 
-    - name: Join the peer to the channel
-      hyperledger.fabric-ansible-collection.peer_channel:
-        api_endpoint: "{{ api_endpoint }}"
-        api_authtype: "{{ api_authtype }}"
-        api_key: "{{ api_key }}"
-        api_secret: "{{ api_secret | default(omit) }}"
-        api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-        operation: join
-        peer: "{{ org1_peer_name }}"
-        identity: "{{ org1_name }} Admin.json"
-        msp_id: "{{ org1_msp_id }}"
-        path: channel_genesis_block.bin
+      - name: Join the peer to the channel
+        hyperledger.fabric_ansible_collection.peer_channel:
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+            operation: join
+            peer: "{{ org1_peer_name }}"
+            identity: "{{ org1_name }} Admin.json"
+            msp_id: "{{ org1_msp_id }}"
+            path: channel_genesis_block.bin

--- a/tutorial/11-add-anchor-peer-to-channel.yml
+++ b/tutorial/11-add-anchor-peer-to-channel.yml
@@ -5,85 +5,85 @@
 - name: Add the anchor peer to the channel
   hosts: localhost
   vars_files:
-    - common-vars.yml
-    - org1-vars.yml
+      - common-vars.yml
+      - org1-vars.yml
   tasks:
-    - name: Get the ordering service information
-      hyperledger.fabric-ansible-collection.ordering_service_info:
-        api_endpoint: "{{ api_endpoint }}"
-        api_authtype: "{{ api_authtype }}"
-        api_key: "{{ api_key }}"
-        api_secret: "{{ api_secret | default(omit) }}"
-        api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-        name: "{{ ordering_service_name }}"
-      register: ordering_service
+      - name: Get the ordering service information
+        hyperledger.fabric_ansible_collection.ordering_service_info:
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+            name: "{{ ordering_service_name }}"
+        register: ordering_service
 
-    - name: Fail if the ordering service does not exist
-      fail:
-        msg: "{{ ordering_service_name }} does not exist"
-      when: not ordering_service.exists
+      - name: Fail if the ordering service does not exist
+        fail:
+            msg: "{{ ordering_service_name }} does not exist"
+        when: not ordering_service.exists
 
-    - name: Fetch the channel configuration
-      hyperledger.fabric-ansible-collection.channel_config:
-        api_endpoint: "{{ api_endpoint }}"
-        api_authtype: "{{ api_authtype }}"
-        api_key: "{{ api_key }}"
-        api_secret: "{{ api_secret | default(omit) }}"
-        api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-        ordering_service: "{{ ordering_service_name }}"
-        identity: "{{ org1_name }} Admin.json"
-        msp_id: "{{ org1_msp_id }}"
-        operation: fetch
-        name: "{{ channel_name }}"
-        path: original_config.bin
+      - name: Fetch the channel configuration
+        hyperledger.fabric_ansible_collection.channel_config:
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+            ordering_service: "{{ ordering_service_name }}"
+            identity: "{{ org1_name }} Admin.json"
+            msp_id: "{{ org1_msp_id }}"
+            operation: fetch
+            name: "{{ channel_name }}"
+            path: original_config.bin
 
-    - name: Create a copy of the channel configuration
-      copy:
-        src: original_config.bin
-        dest: updated_config.bin
+      - name: Create a copy of the channel configuration
+        copy:
+            src: original_config.bin
+            dest: updated_config.bin
 
-    - name: Update the organization
-      hyperledger.fabric-ansible-collection.channel_member:
-        state: present
-        api_endpoint: "{{ api_endpoint }}"
-        api_authtype: "{{ api_authtype }}"
-        api_key: "{{ api_key }}"
-        api_secret: "{{ api_secret | default(omit) }}"
-        api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-        organization: "{{ org1_name }}"
-        anchor_peers:
-          - "{{ org1_peer_name }}"
-        path: updated_config.bin
+      - name: Update the organization
+        hyperledger.fabric_ansible_collection.channel_member:
+            state: present
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+            organization: "{{ org1_name }}"
+            anchor_peers:
+                - "{{ org1_peer_name }}"
+            path: updated_config.bin
 
-    - name: Compute the channel configuration update
-      hyperledger.fabric-ansible-collection.channel_config:
-        operation: compute_update
-        name: "{{ channel_name }}"
-        original: original_config.bin
-        updated: updated_config.bin
-        path: config_update.bin
-      register: compute_update
+      - name: Compute the channel configuration update
+        hyperledger.fabric_ansible_collection.channel_config:
+            operation: compute_update
+            name: "{{ channel_name }}"
+            original: original_config.bin
+            updated: updated_config.bin
+            path: config_update.bin
+        register: compute_update
 
-    - name: Sign the channel configuration update
-      hyperledger.fabric-ansible-collection.channel_config:
-        operation: sign_update
-        identity: "{{ org1_name }} Admin.json"
-        msp_id: "{{ org1_msp_id }}"
-        name: "{{ channel_name }}"
-        path: config_update.bin
-      when: compute_update.path
+      - name: Sign the channel configuration update
+        hyperledger.fabric_ansible_collection.channel_config:
+            operation: sign_update
+            identity: "{{ org1_name }} Admin.json"
+            msp_id: "{{ org1_msp_id }}"
+            name: "{{ channel_name }}"
+            path: config_update.bin
+        when: compute_update.path
 
-    - name: Apply the channel configuration update
-      hyperledger.fabric-ansible-collection.channel_config:
-        api_endpoint: "{{ api_endpoint }}"
-        api_authtype: "{{ api_authtype }}"
-        api_key: "{{ api_key }}"
-        api_secret: "{{ api_secret | default(omit) }}"
-        api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-        operation: apply_update
-        ordering_service: "{{ ordering_service_name }}"
-        identity: "{{ org1_name }} Admin.json"
-        msp_id: "{{ org1_msp_id }}"
-        name: "{{ channel_name }}"
-        path: config_update.bin
-      when: compute_update.path
+      - name: Apply the channel configuration update
+        hyperledger.fabric_ansible_collection.channel_config:
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+            operation: apply_update
+            ordering_service: "{{ ordering_service_name }}"
+            identity: "{{ org1_name }} Admin.json"
+            msp_id: "{{ org1_msp_id }}"
+            name: "{{ channel_name }}"
+            path: config_update.bin
+        when: compute_update.path

--- a/tutorial/12-create-endorsing-organization-components.yml
+++ b/tutorial/12-create-endorsing-organization-components.yml
@@ -5,13 +5,13 @@
 - name: Create components for an endorsing organization
   hosts: localhost
   vars:
-    state: present
-    organization_name: "{{ org2_name }}"
-    organization_msp_id: "{{ org2_msp_id }}"
-    ca_name: "{{ org2_ca_name }}"
-    peer_name: "{{ org2_peer_name }}"
+      state: present
+      organization_name: "{{ org2_name }}"
+      organization_msp_id: "{{ org2_msp_id }}"
+      ca_name: "{{ org2_ca_name }}"
+      peer_name: "{{ org2_peer_name }}"
   vars_files:
-    - common-vars.yml
-    - org2-vars.yml
+      - common-vars.yml
+      - org2-vars.yml
   roles:
-    - hyperledger.fabric-ansible-collection.endorsing_organization
+      - hyperledger.fabric_ansible_collection.endorsing_organization

--- a/tutorial/13-export-organization.yml
+++ b/tutorial/13-export-organization.yml
@@ -5,25 +5,25 @@
 - name: Export the organization
   hosts: localhost
   vars_files:
-    - common-vars.yml
-    - org2-vars.yml
+      - common-vars.yml
+      - org2-vars.yml
   tasks:
-    - name: Get the organization
-      hyperledger.fabric-ansible-collection.organization_info:
-        api_endpoint: "{{ api_endpoint }}"
-        api_authtype: "{{ api_authtype }}"
-        api_key: "{{ api_key }}"
-        api_secret: "{{ api_secret | default(omit) }}"
-        api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-        name: "{{ org2_name }}"
-      register: result
+      - name: Get the organization
+        hyperledger.fabric_ansible_collection.organization_info:
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+            name: "{{ org2_name }}"
+        register: result
 
-    - name: Fail if the organization does not exist
-      fail:
-        msg: "Organization {{ org2_name }} does not exist"
-      when: not result.exists
+      - name: Fail if the organization does not exist
+        fail:
+            msg: "Organization {{ org2_name }} does not exist"
+        when: not result.exists
 
-    - name: Store the organization in a file
-      copy:
-        content: "{{ result.organization | to_nice_json }}"
-        dest: "{{ org2_name }}.json"
+      - name: Store the organization in a file
+        copy:
+            content: "{{ result.organization | to_nice_json }}"
+            dest: "{{ org2_name }}.json"

--- a/tutorial/14-import-organization.yml
+++ b/tutorial/14-import-organization.yml
@@ -5,14 +5,14 @@
 - name: Import the organization
   hosts: localhost
   vars_files:
-    - common-vars.yml
-    - org1-vars.yml
+      - common-vars.yml
+      - org1-vars.yml
   tasks:
-    - name: Import the organization
-      hyperledger.fabric-ansible-collection.external_organization:
-        api_endpoint: "{{ api_endpoint }}"
-        api_authtype: "{{ api_authtype }}"
-        api_key: "{{ api_key }}"
-        api_secret: "{{ api_secret | default(omit) }}"
-        api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-        organization: "{{ lookup('file', org2_name+'.json') }}"
+      - name: Import the organization
+        hyperledger.fabric_ansible_collection.external_organization:
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+            organization: "{{ lookup('file', org2_name+'.json') }}"

--- a/tutorial/15-add-organization-to-channel.yml
+++ b/tutorial/15-add-organization-to-channel.yml
@@ -5,118 +5,118 @@
 - name: Add the organization to the channel
   hosts: localhost
   vars_files:
-    - common-vars.yml
-    - org1-vars.yml
+      - common-vars.yml
+      - org1-vars.yml
   tasks:
-    - name: Get the ordering service information
-      hyperledger.fabric-ansible-collection.ordering_service_info:
-        api_endpoint: "{{ api_endpoint }}"
-        api_authtype: "{{ api_authtype }}"
-        api_key: "{{ api_key }}"
-        api_secret: "{{ api_secret | default(omit) }}"
-        api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-        name: "{{ ordering_service_name }}"
-      register: ordering_service
+      - name: Get the ordering service information
+        hyperledger.fabric_ansible_collection.ordering_service_info:
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+            name: "{{ ordering_service_name }}"
+        register: ordering_service
 
-    - name: Fail if the ordering service does not exist
-      fail:
-        msg: "{{ ordering_service_name }} does not exist"
-      when: not ordering_service.exists
+      - name: Fail if the ordering service does not exist
+        fail:
+            msg: "{{ ordering_service_name }} does not exist"
+        when: not ordering_service.exists
 
-    - name: Fetch the channel configuration
-      hyperledger.fabric-ansible-collection.channel_config:
-        api_endpoint: "{{ api_endpoint }}"
-        api_authtype: "{{ api_authtype }}"
-        api_key: "{{ api_key }}"
-        api_secret: "{{ api_secret | default(omit) }}"
-        api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-        ordering_service: "{{ ordering_service_name }}"
-        identity: "{{ org1_name }} Admin.json"
-        msp_id: "{{ org1_msp_id }}"
-        operation: fetch
-        name: "{{ channel_name }}"
-        path: original_config.bin
+      - name: Fetch the channel configuration
+        hyperledger.fabric_ansible_collection.channel_config:
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+            ordering_service: "{{ ordering_service_name }}"
+            identity: "{{ org1_name }} Admin.json"
+            msp_id: "{{ org1_msp_id }}"
+            operation: fetch
+            name: "{{ channel_name }}"
+            path: original_config.bin
 
-    - name: Create a copy of the channel configuration
-      copy:
-        src: original_config.bin
-        dest: updated_config.bin
+      - name: Create a copy of the channel configuration
+        copy:
+            src: original_config.bin
+            dest: updated_config.bin
 
-    - name: Add the organization to the channel
-      hyperledger.fabric-ansible-collection.channel_member:
-        state: present
-        api_endpoint: "{{ api_endpoint }}"
-        api_authtype: "{{ api_authtype }}"
-        api_key: "{{ api_key }}"
-        api_secret: "{{ api_secret | default(omit) }}"
-        api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-        organization: "{{ org2_name }}"
-        path: updated_config.bin
+      - name: Add the organization to the channel
+        hyperledger.fabric_ansible_collection.channel_member:
+            state: present
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+            organization: "{{ org2_name }}"
+            path: updated_config.bin
 
-    - name: Update the channel admins policy
-      hyperledger.fabric-ansible-collection.channel_policy:
-        state: present
-        path: updated_config.bin
-        name: Admins
-        policy: "{{ lookup('template', '15-admins-policy.json.j2') }}"
+      - name: Update the channel admins policy
+        hyperledger.fabric_ansible_collection.channel_policy:
+            state: present
+            path: updated_config.bin
+            name: Admins
+            policy: "{{ lookup('template', '15-admins-policy.json.j2') }}"
 
-    - name: Update the channel readers policy
-      hyperledger.fabric-ansible-collection.channel_policy:
-        state: present
-        path: updated_config.bin
-        name: Readers
-        policy: "{{ lookup('template', '15-readers-policy.json.j2') }}"
+      - name: Update the channel readers policy
+        hyperledger.fabric_ansible_collection.channel_policy:
+            state: present
+            path: updated_config.bin
+            name: Readers
+            policy: "{{ lookup('template', '15-readers-policy.json.j2') }}"
 
-    - name: Update the channel writers policy
-      hyperledger.fabric-ansible-collection.channel_policy:
-        state: present
-        path: updated_config.bin
-        name: Writers
-        policy: "{{ lookup('template', '15-writers-policy.json.j2') }}"
+      - name: Update the channel writers policy
+        hyperledger.fabric_ansible_collection.channel_policy:
+            state: present
+            path: updated_config.bin
+            name: Writers
+            policy: "{{ lookup('template', '15-writers-policy.json.j2') }}"
 
-    - name: Update the channel endorsement policy
-      hyperledger.fabric-ansible-collection.channel_policy:
-        state: present
-        path: updated_config.bin
-        name: Endorsement
-        policy: "{{ lookup('template', '15-endorsement-policy.json.j2') }}"
+      - name: Update the channel endorsement policy
+        hyperledger.fabric_ansible_collection.channel_policy:
+            state: present
+            path: updated_config.bin
+            name: Endorsement
+            policy: "{{ lookup('template', '15-endorsement-policy.json.j2') }}"
 
-    - name: Update the channel lifecycle endorsement policy
-      hyperledger.fabric-ansible-collection.channel_policy:
-        state: present
-        path: updated_config.bin
-        name: LifecycleEndorsement
-        policy: "{{ lookup('template', '15-lifecycle-endorsement-policy.json.j2') }}"
+      - name: Update the channel lifecycle endorsement policy
+        hyperledger.fabric_ansible_collection.channel_policy:
+            state: present
+            path: updated_config.bin
+            name: LifecycleEndorsement
+            policy: "{{ lookup('template', '15-lifecycle-endorsement-policy.json.j2') }}"
 
-    - name: Compute the channel configuration update
-      hyperledger.fabric-ansible-collection.channel_config:
-        operation: compute_update
-        name: "{{ channel_name }}"
-        original: original_config.bin
-        updated: updated_config.bin
-        path: config_update.bin
-      register: compute_update
+      - name: Compute the channel configuration update
+        hyperledger.fabric_ansible_collection.channel_config:
+            operation: compute_update
+            name: "{{ channel_name }}"
+            original: original_config.bin
+            updated: updated_config.bin
+            path: config_update.bin
+        register: compute_update
 
-    - name: Sign the channel configuration update
-      hyperledger.fabric-ansible-collection.channel_config:
-        operation: sign_update
-        identity: "{{ org1_name }} Admin.json"
-        msp_id: "{{ org1_msp_id }}"
-        name: "{{ channel_name }}"
-        path: config_update.bin
-      when: compute_update.path
+      - name: Sign the channel configuration update
+        hyperledger.fabric_ansible_collection.channel_config:
+            operation: sign_update
+            identity: "{{ org1_name }} Admin.json"
+            msp_id: "{{ org1_msp_id }}"
+            name: "{{ channel_name }}"
+            path: config_update.bin
+        when: compute_update.path
 
-    - name: Apply the channel configuration update
-      hyperledger.fabric-ansible-collection.channel_config:
-        api_endpoint: "{{ api_endpoint }}"
-        api_authtype: "{{ api_authtype }}"
-        api_key: "{{ api_key }}"
-        api_secret: "{{ api_secret | default(omit) }}"
-        api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-        operation: apply_update
-        ordering_service: "{{ ordering_service_name }}"
-        identity: "{{ org1_name }} Admin.json"
-        msp_id: "{{ org1_msp_id }}"
-        name: "{{ channel_name }}"
-        path: config_update.bin
-      when: compute_update.path
+      - name: Apply the channel configuration update
+        hyperledger.fabric_ansible_collection.channel_config:
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+            operation: apply_update
+            ordering_service: "{{ ordering_service_name }}"
+            identity: "{{ org1_name }} Admin.json"
+            msp_id: "{{ org1_msp_id }}"
+            name: "{{ channel_name }}"
+            path: config_update.bin
+        when: compute_update.path

--- a/tutorial/16-import-ordering-service.yml
+++ b/tutorial/16-import-ordering-service.yml
@@ -5,14 +5,14 @@
 - name: Import the ordering service
   hosts: localhost
   vars_files:
-    - common-vars.yml
-    - org2-vars.yml
+      - common-vars.yml
+      - org2-vars.yml
   tasks:
-    - name: Import the ordering service
-      hyperledger.fabric-ansible-collection.external_ordering_service:
-        api_endpoint: "{{ api_endpoint }}"
-        api_authtype: "{{ api_authtype }}"
-        api_key: "{{ api_key }}"
-        api_secret: "{{ api_secret | default(omit) }}"
-        api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-        ordering_service: "{{ lookup('file', ordering_service_name+'.json') }}"
+      - name: Import the ordering service
+        hyperledger.fabric_ansible_collection.external_ordering_service:
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+            ordering_service: "{{ lookup('file', ordering_service_name+'.json') }}"

--- a/tutorial/17-join-peer-to-channel.yml
+++ b/tutorial/17-join-peer-to-channel.yml
@@ -5,33 +5,33 @@
 - name: Join the channel
   hosts: localhost
   vars_files:
-    - common-vars.yml
-    - org2-vars.yml
+      - common-vars.yml
+      - org2-vars.yml
   tasks:
-    - name: Fetch the genesis block for the channel
-      hyperledger.fabric-ansible-collection.channel_block:
-        api_endpoint: "{{ api_endpoint }}"
-        api_authtype: "{{ api_authtype }}"
-        api_key: "{{ api_key }}"
-        api_secret: "{{ api_secret | default(omit) }}"
-        api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-        operation: fetch
-        ordering_service: "{{ ordering_service_name }}"
-        identity: "{{ org2_name }} Admin.json"
-        msp_id: "{{ org2_msp_id }}"
-        name: "{{ channel_name }}"
-        target: "0"
-        path: channel_genesis_block.bin
+      - name: Fetch the genesis block for the channel
+        hyperledger.fabric_ansible_collection.channel_block:
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+            operation: fetch
+            ordering_service: "{{ ordering_service_name }}"
+            identity: "{{ org2_name }} Admin.json"
+            msp_id: "{{ org2_msp_id }}"
+            name: "{{ channel_name }}"
+            target: "0"
+            path: channel_genesis_block.bin
 
-    - name: Join the peer to the channel
-      hyperledger.fabric-ansible-collection.peer_channel:
-        api_endpoint: "{{ api_endpoint }}"
-        api_authtype: "{{ api_authtype }}"
-        api_key: "{{ api_key }}"
-        api_secret: "{{ api_secret | default(omit) }}"
-        api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-        operation: join
-        peer: "{{ org2_peer_name }}"
-        identity: "{{ org2_name }} Admin.json"
-        msp_id: "{{ org2_msp_id }}"
-        path: channel_genesis_block.bin
+      - name: Join the peer to the channel
+        hyperledger.fabric_ansible_collection.peer_channel:
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+            operation: join
+            peer: "{{ org2_peer_name }}"
+            identity: "{{ org2_name }} Admin.json"
+            msp_id: "{{ org2_msp_id }}"
+            path: channel_genesis_block.bin

--- a/tutorial/18-add-anchor-peer-to-channel.yml
+++ b/tutorial/18-add-anchor-peer-to-channel.yml
@@ -5,85 +5,85 @@
 - name: Add the anchor peer to the channel
   hosts: localhost
   vars_files:
-    - common-vars.yml
-    - org2-vars.yml
+      - common-vars.yml
+      - org2-vars.yml
   tasks:
-    - name: Get the ordering service information
-      hyperledger.fabric-ansible-collection.ordering_service_info:
-        api_endpoint: "{{ api_endpoint }}"
-        api_authtype: "{{ api_authtype }}"
-        api_key: "{{ api_key }}"
-        api_secret: "{{ api_secret | default(omit) }}"
-        api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-        name: "{{ ordering_service_name }}"
-      register: ordering_service
+      - name: Get the ordering service information
+        hyperledger.fabric_ansible_collection.ordering_service_info:
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+            name: "{{ ordering_service_name }}"
+        register: ordering_service
 
-    - name: Fail if the ordering service does not exist
-      fail:
-        msg: "{{ ordering_service_name }} does not exist"
-      when: not ordering_service.exists
+      - name: Fail if the ordering service does not exist
+        fail:
+            msg: "{{ ordering_service_name }} does not exist"
+        when: not ordering_service.exists
 
-    - name: Fetch the channel configuration
-      hyperledger.fabric-ansible-collection.channel_config:
-        api_endpoint: "{{ api_endpoint }}"
-        api_authtype: "{{ api_authtype }}"
-        api_key: "{{ api_key }}"
-        api_secret: "{{ api_secret | default(omit) }}"
-        api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-        ordering_service: "{{ ordering_service_name }}"
-        identity: "{{ org2_name }} Admin.json"
-        msp_id: "{{ org2_msp_id }}"
-        operation: fetch
-        name: "{{ channel_name }}"
-        path: original_config.bin
+      - name: Fetch the channel configuration
+        hyperledger.fabric_ansible_collection.channel_config:
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+            ordering_service: "{{ ordering_service_name }}"
+            identity: "{{ org2_name }} Admin.json"
+            msp_id: "{{ org2_msp_id }}"
+            operation: fetch
+            name: "{{ channel_name }}"
+            path: original_config.bin
 
-    - name: Create a copy of the channel configuration
-      copy:
-        src: original_config.bin
-        dest: updated_config.bin
+      - name: Create a copy of the channel configuration
+        copy:
+            src: original_config.bin
+            dest: updated_config.bin
 
-    - name: Update the organization
-      hyperledger.fabric-ansible-collection.channel_member:
-        state: present
-        api_endpoint: "{{ api_endpoint }}"
-        api_authtype: "{{ api_authtype }}"
-        api_key: "{{ api_key }}"
-        api_secret: "{{ api_secret | default(omit) }}"
-        api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-        organization: "{{ org2_name }}"
-        anchor_peers:
-          - "{{ org2_peer_name }}"
-        path: updated_config.bin
+      - name: Update the organization
+        hyperledger.fabric_ansible_collection.channel_member:
+            state: present
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+            organization: "{{ org2_name }}"
+            anchor_peers:
+                - "{{ org2_peer_name }}"
+            path: updated_config.bin
 
-    - name: Compute the channel configuration update
-      hyperledger.fabric-ansible-collection.channel_config:
-        operation: compute_update
-        name: "{{ channel_name }}"
-        original: original_config.bin
-        updated: updated_config.bin
-        path: config_update.bin
-      register: compute_update
+      - name: Compute the channel configuration update
+        hyperledger.fabric_ansible_collection.channel_config:
+            operation: compute_update
+            name: "{{ channel_name }}"
+            original: original_config.bin
+            updated: updated_config.bin
+            path: config_update.bin
+        register: compute_update
 
-    - name: Sign the channel configuration update
-      hyperledger.fabric-ansible-collection.channel_config:
-        operation: sign_update
-        identity: "{{ org2_name }} Admin.json"
-        msp_id: "{{ org2_msp_id }}"
-        name: "{{ channel_name }}"
-        path: config_update.bin
-      when: compute_update.path
+      - name: Sign the channel configuration update
+        hyperledger.fabric_ansible_collection.channel_config:
+            operation: sign_update
+            identity: "{{ org2_name }} Admin.json"
+            msp_id: "{{ org2_msp_id }}"
+            name: "{{ channel_name }}"
+            path: config_update.bin
+        when: compute_update.path
 
-    - name: Apply the channel configuration update
-      hyperledger.fabric-ansible-collection.channel_config:
-        api_endpoint: "{{ api_endpoint }}"
-        api_authtype: "{{ api_authtype }}"
-        api_key: "{{ api_key }}"
-        api_secret: "{{ api_secret | default(omit) }}"
-        api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-        operation: apply_update
-        ordering_service: "{{ ordering_service_name }}"
-        identity: "{{ org2_name }} Admin.json"
-        msp_id: "{{ org2_msp_id }}"
-        name: "{{ channel_name }}"
-        path: config_update.bin
-      when: compute_update.path
+      - name: Apply the channel configuration update
+        hyperledger.fabric_ansible_collection.channel_config:
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+            operation: apply_update
+            ordering_service: "{{ ordering_service_name }}"
+            identity: "{{ org2_name }} Admin.json"
+            msp_id: "{{ org2_msp_id }}"
+            name: "{{ channel_name }}"
+            path: config_update.bin
+        when: compute_update.path

--- a/tutorial/19-install-and-approve-chaincode.yml
+++ b/tutorial/19-install-and-approve-chaincode.yml
@@ -5,36 +5,36 @@
 - name: Install and approve chaincode
   hosts: localhost
   vars_files:
-    - common-vars.yml
-    - org1-vars.yml
+      - common-vars.yml
+      - org1-vars.yml
   tasks:
-    - name: Install the chaincode on the peer
-      hyperledger.fabric-ansible-collection.installed_chaincode:
-        api_endpoint: "{{ api_endpoint }}"
-        api_authtype: "{{ api_authtype }}"
-        api_key: "{{ api_key }}"
-        api_secret: "{{ api_secret | default(omit) }}"
-        api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-        peer: "{{ org1_peer_name }}"
-        identity: "{{ org1_name }} Admin.json"
-        msp_id: "{{ org1_msp_id }}"
-        path: "{{ smart_contract_package }}"
-      register: result
+      - name: Install the chaincode on the peer
+        hyperledger.fabric_ansible_collection.installed_chaincode:
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+            peer: "{{ org1_peer_name }}"
+            identity: "{{ org1_name }} Admin.json"
+            msp_id: "{{ org1_msp_id }}"
+            path: "{{ smart_contract_package }}"
+        register: result
 
-    - name: Approve the chaincode on the channel
-      hyperledger.fabric-ansible-collection.approved_chaincode:
-        api_endpoint: "{{ api_endpoint }}"
-        api_authtype: "{{ api_authtype }}"
-        api_key: "{{ api_key }}"
-        api_secret: "{{ api_secret | default(omit) }}"
-        api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-        peer: "{{ org1_peer_name }}"
-        identity: "{{ org1_name }} Admin.json"
-        msp_id: "{{ org1_msp_id }}"
-        channel: "{{ channel_name }}"
-        name: "{{ smart_contract_name }}"
-        version: "{{ smart_contract_version }}"
-        package_id: "{{ result.installed_chaincode.package_id }}"
-        sequence: "{{ smart_contract_sequence }}"
-        endorsement_policy: "{{ smart_contract_endorsement_policy | default(omit) }}"
-        collections_config: "{{ smart_contract_collections_file | default(omit) }}"
+      - name: Approve the chaincode on the channel
+        hyperledger.fabric_ansible_collection.approved_chaincode:
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+            peer: "{{ org1_peer_name }}"
+            identity: "{{ org1_name }} Admin.json"
+            msp_id: "{{ org1_msp_id }}"
+            channel: "{{ channel_name }}"
+            name: "{{ smart_contract_name }}"
+            version: "{{ smart_contract_version }}"
+            package_id: "{{ result.installed_chaincode.package_id }}"
+            sequence: "{{ smart_contract_sequence }}"
+            endorsement_policy: "{{ smart_contract_endorsement_policy | default(omit) }}"
+            collections_config: "{{ smart_contract_collections_file | default(omit) }}"

--- a/tutorial/20-install-and-approve-chaincode.yml
+++ b/tutorial/20-install-and-approve-chaincode.yml
@@ -5,36 +5,36 @@
 - name: Install and approve chaincode
   hosts: localhost
   vars_files:
-    - common-vars.yml
-    - org2-vars.yml
+      - common-vars.yml
+      - org2-vars.yml
   tasks:
-    - name: Install the chaincode on the peer
-      hyperledger.fabric-ansible-collection.installed_chaincode:
-        api_endpoint: "{{ api_endpoint }}"
-        api_authtype: "{{ api_authtype }}"
-        api_key: "{{ api_key }}"
-        api_secret: "{{ api_secret | default(omit) }}"
-        api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-        peer: "{{ org2_peer_name }}"
-        identity: "{{ org2_name }} Admin.json"
-        msp_id: "{{ org2_msp_id }}"
-        path: "{{ smart_contract_package }}"
-      register: result
+      - name: Install the chaincode on the peer
+        hyperledger.fabric_ansible_collection.installed_chaincode:
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+            peer: "{{ org2_peer_name }}"
+            identity: "{{ org2_name }} Admin.json"
+            msp_id: "{{ org2_msp_id }}"
+            path: "{{ smart_contract_package }}"
+        register: result
 
-    - name: Approve the chaincode on the channel
-      hyperledger.fabric-ansible-collection.approved_chaincode:
-        api_endpoint: "{{ api_endpoint }}"
-        api_authtype: "{{ api_authtype }}"
-        api_key: "{{ api_key }}"
-        api_secret: "{{ api_secret | default(omit) }}"
-        api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-        peer: "{{ org2_peer_name }}"
-        identity: "{{ org2_name }} Admin.json"
-        msp_id: "{{ org2_msp_id }}"
-        channel: "{{ channel_name }}"
-        name: "{{ smart_contract_name }}"
-        version: "{{ smart_contract_version }}"
-        package_id: "{{ result.installed_chaincode.package_id }}"
-        sequence: "{{ smart_contract_sequence }}"
-        endorsement_policy: "{{ smart_contract_endorsement_policy | default(omit) }}"
-        collections_config: "{{ smart_contract_collections_file | default(omit) }}"
+      - name: Approve the chaincode on the channel
+        hyperledger.fabric_ansible_collection.approved_chaincode:
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+            peer: "{{ org2_peer_name }}"
+            identity: "{{ org2_name }} Admin.json"
+            msp_id: "{{ org2_msp_id }}"
+            channel: "{{ channel_name }}"
+            name: "{{ smart_contract_name }}"
+            version: "{{ smart_contract_version }}"
+            package_id: "{{ result.installed_chaincode.package_id }}"
+            sequence: "{{ smart_contract_sequence }}"
+            endorsement_policy: "{{ smart_contract_endorsement_policy | default(omit) }}"
+            collections_config: "{{ smart_contract_collections_file | default(omit) }}"

--- a/tutorial/21-commit-chaincode.yml
+++ b/tutorial/21-commit-chaincode.yml
@@ -5,25 +5,25 @@
 - name: Commit chaincode
   hosts: localhost
   vars_files:
-    - common-vars.yml
-    - org1-vars.yml
+      - common-vars.yml
+      - org1-vars.yml
   tasks:
-    - name: Commit the chaincode on the channel
-      hyperledger.fabric-ansible-collection.committed_chaincode:
-        api_endpoint: "{{ api_endpoint }}"
-        api_authtype: "{{ api_authtype }}"
-        api_key: "{{ api_key }}"
-        api_secret: "{{ api_secret | default(omit) }}"
-        api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-        peer: "{{ org1_peer_name }}"
-        identity: "{{ org1_name }} Admin.json"
-        msp_id: "{{ org1_msp_id }}"
-        channel: "{{ channel_name }}"
-        organizations:
-          - "{{ org1_name }}"
-          - "{{ org2_name }}"
-        name: "{{ smart_contract_name }}"
-        version: "{{ smart_contract_version }}"
-        sequence: "{{ smart_contract_sequence }}"
-        endorsement_policy: "{{ smart_contract_endorsement_policy | default(omit) }}"
-        collections_config: "{{ smart_contract_collections_file | default(omit) }}"
+      - name: Commit the chaincode on the channel
+        hyperledger.fabric_ansible_collection.committed_chaincode:
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+            peer: "{{ org1_peer_name }}"
+            identity: "{{ org1_name }} Admin.json"
+            msp_id: "{{ org1_msp_id }}"
+            channel: "{{ channel_name }}"
+            organizations:
+                - "{{ org1_name }}"
+                - "{{ org2_name }}"
+            name: "{{ smart_contract_name }}"
+            version: "{{ smart_contract_version }}"
+            sequence: "{{ smart_contract_sequence }}"
+            endorsement_policy: "{{ smart_contract_endorsement_policy | default(omit) }}"
+            collections_config: "{{ smart_contract_collections_file | default(omit) }}"

--- a/tutorial/22-register-application.yml
+++ b/tutorial/22-register-application.yml
@@ -5,36 +5,36 @@
 - name: Register application
   hosts: localhost
   vars_files:
-    - common-vars.yml
-    - org1-vars.yml
+      - common-vars.yml
+      - org1-vars.yml
   tasks:
-    - name: Register a new identity
-      hyperledger.fabric-ansible-collection.registered_identity:
-        api_endpoint: "{{ api_endpoint }}"
-        api_authtype: "{{ api_authtype }}"
-        api_key: "{{ api_key }}"
-        api_secret: "{{ api_secret | default(omit) }}"
-        api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-        certificate_authority: "{{ org1_ca_name }}"
-        registrar: "{{ org1_ca_name }} Admin.json"
-        enrollment_id: "{{ application_enrollment_id }}"
-        enrollment_secret: "{{ application_enrollment_secret }}"
-        max_enrollments: "{{ application_max_enrollments }}"
-        type: "{{ application_enrollment_type }}"
-        attributes:
-          - name: "{{ smart_contract_name }}.admin"
-            value: "true"
+      - name: Register a new identity
+        hyperledger.fabric_ansible_collection.registered_identity:
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+            certificate_authority: "{{ org1_ca_name }}"
+            registrar: "{{ org1_ca_name }} Admin.json"
+            enrollment_id: "{{ application_enrollment_id }}"
+            enrollment_secret: "{{ application_enrollment_secret }}"
+            max_enrollments: "{{ application_max_enrollments }}"
+            type: "{{ application_enrollment_type }}"
+            attributes:
+                - name: "{{ smart_contract_name }}.admin"
+                  value: "true"
 
-    - name: Create a connection profile
-      hyperledger.fabric-ansible-collection.connection_profile:
-        api_endpoint: "{{ api_endpoint }}"
-        api_authtype: "{{ api_authtype }}"
-        api_key: "{{ api_key }}"
-        api_secret: "{{ api_secret | default(omit) }}"
-        api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-        name: "{{ org1_name }} Gateway"
-        path: "{{ org1_name }} Gateway.json"
-        organization: "{{ org1_name }}"
-        certificate_authority: "{{ org1_ca_name }}"
-        peers:
-          - "{{ org1_peer_name }}"
+      - name: Create a connection profile
+        hyperledger.fabric_ansible_collection.connection_profile:
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+            name: "{{ org1_name }} Gateway"
+            path: "{{ org1_name }} Gateway.json"
+            organization: "{{ org1_name }}"
+            certificate_authority: "{{ org1_ca_name }}"
+            peers:
+                - "{{ org1_peer_name }}"

--- a/tutorial/23-register-application.yml
+++ b/tutorial/23-register-application.yml
@@ -5,36 +5,36 @@
 - name: Register application
   hosts: localhost
   vars_files:
-    - common-vars.yml
-    - org2-vars.yml
+      - common-vars.yml
+      - org2-vars.yml
   tasks:
-    - name: Register a new identity
-      hyperledger.fabric-ansible-collection.registered_identity:
-        api_endpoint: "{{ api_endpoint }}"
-        api_authtype: "{{ api_authtype }}"
-        api_key: "{{ api_key }}"
-        api_secret: "{{ api_secret | default(omit) }}"
-        api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-        certificate_authority: "{{ org2_ca_name }}"
-        registrar: "{{ org2_ca_name }} Admin.json"
-        enrollment_id: "{{ application_enrollment_id }}"
-        enrollment_secret: "{{ application_enrollment_secret }}"
-        max_enrollments: "{{ application_max_enrollments }}"
-        type: "{{ application_enrollment_type }}"
-        attributes:
-          - name: "{{ smart_contract_name }}.admin"
-            value: "true"
+      - name: Register a new identity
+        hyperledger.fabric_ansible_collection.registered_identity:
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+            certificate_authority: "{{ org2_ca_name }}"
+            registrar: "{{ org2_ca_name }} Admin.json"
+            enrollment_id: "{{ application_enrollment_id }}"
+            enrollment_secret: "{{ application_enrollment_secret }}"
+            max_enrollments: "{{ application_max_enrollments }}"
+            type: "{{ application_enrollment_type }}"
+            attributes:
+                - name: "{{ smart_contract_name }}.admin"
+                  value: "true"
 
-    - name: Create a connection profile
-      hyperledger.fabric-ansible-collection.connection_profile:
-        api_endpoint: "{{ api_endpoint }}"
-        api_authtype: "{{ api_authtype }}"
-        api_key: "{{ api_key }}"
-        api_secret: "{{ api_secret | default(omit) }}"
-        api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-        name: "{{ org2_name }} Gateway"
-        path: "{{ org2_name }} Gateway.json"
-        organization: "{{ org2_name }}"
-        certificate_authority: "{{ org2_ca_name }}"
-        peers:
-          - "{{ org2_peer_name }}"
+      - name: Create a connection profile
+        hyperledger.fabric_ansible_collection.connection_profile:
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+            name: "{{ org2_name }} Gateway"
+            path: "{{ org2_name }} Gateway.json"
+            organization: "{{ org2_name }}"
+            certificate_authority: "{{ org2_ca_name }}"
+            peers:
+                - "{{ org2_peer_name }}"

--- a/tutorial/97-delete-endorsing-organization-components.yml
+++ b/tutorial/97-delete-endorsing-organization-components.yml
@@ -5,40 +5,40 @@
 - name: Delete components for an endorsing organization
   hosts: localhost
   vars:
-    state: absent
-    organization_name: "{{ org1_name }}"
-    ca_name: "{{ org1_ca_name }}"
-    peer_name: "{{ org1_peer_name }}"
+      state: absent
+      organization_name: "{{ org1_name }}"
+      ca_name: "{{ org1_ca_name }}"
+      peer_name: "{{ org1_peer_name }}"
   vars_files:
-    - common-vars.yml
-    - org1-vars.yml
+      - common-vars.yml
+      - org1-vars.yml
   roles:
-    - hyperledger.fabric-ansible-collection.endorsing_organization
+      - hyperledger.fabric_ansible_collection.endorsing_organization
 
 - name: Remove imported components
   hosts: localhost
   vars_files:
-    - common-vars.yml
-    - org1-vars.yml
+      - common-vars.yml
+      - org1-vars.yml
   tasks:
-    - name: Remove imported ordering service
-      hyperledger.fabric-ansible-collection.external_ordering_service:
-        api_endpoint: "{{ api_endpoint }}"
-        api_authtype: "{{ api_authtype }}"
-        api_key: "{{ api_key }}"
-        api_secret: "{{ api_secret | default(omit) }}"
-        api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-        state: absent
-        name: "{{ ordering_service_name }}"
-      when: import_export_used | default(false)
+      - name: Remove imported ordering service
+        hyperledger.fabric_ansible_collection.external_ordering_service:
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+            state: absent
+            name: "{{ ordering_service_name }}"
+        when: import_export_used | default(false)
 
-    - name: Remove imported organization
-      hyperledger.fabric-ansible-collection.external_organization:
-        api_endpoint: "{{ api_endpoint }}"
-        api_authtype: "{{ api_authtype }}"
-        api_key: "{{ api_key }}"
-        api_secret: "{{ api_secret | default(omit) }}"
-        api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-        state: absent
-        name: "{{ org2_name }}"
-      when: import_export_used | default(false)
+      - name: Remove imported organization
+        hyperledger.fabric_ansible_collection.external_organization:
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+            state: absent
+            name: "{{ org2_name }}"
+        when: import_export_used | default(false)

--- a/tutorial/98-delete-endorsing-organization-components.yml
+++ b/tutorial/98-delete-endorsing-organization-components.yml
@@ -5,29 +5,29 @@
 - name: Delete components for an endorsing organization
   hosts: localhost
   vars:
-    state: absent
-    organization_name: "{{ org2_name }}"
-    ca_name: "{{ org2_ca_name }}"
-    peer_name: "{{ org2_peer_name }}"
+      state: absent
+      organization_name: "{{ org2_name }}"
+      ca_name: "{{ org2_ca_name }}"
+      peer_name: "{{ org2_peer_name }}"
   vars_files:
-    - common-vars.yml
-    - org2-vars.yml
+      - common-vars.yml
+      - org2-vars.yml
   roles:
-    - hyperledger.fabric-ansible-collection.endorsing_organization
+      - hyperledger.fabric_ansible_collection.endorsing_organization
 
 - name: Remove imported components
   hosts: localhost
   vars_files:
-    - common-vars.yml
-    - org2-vars.yml
+      - common-vars.yml
+      - org2-vars.yml
   tasks:
-    - name: Remove imported ordering service
-      hyperledger.fabric-ansible-collection.external_ordering_service:
-        api_endpoint: "{{ api_endpoint }}"
-        api_authtype: "{{ api_authtype }}"
-        api_key: "{{ api_key }}"
-        api_secret: "{{ api_secret | default(omit) }}"
-        api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-        state: absent
-        name: "{{ ordering_service_name }}"
-      when: import_export_used | default(false)
+      - name: Remove imported ordering service
+        hyperledger.fabric_ansible_collection.external_ordering_service:
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+            state: absent
+            name: "{{ ordering_service_name }}"
+        when: import_export_used | default(false)

--- a/tutorial/99-delete-ordering-organization-components.yml
+++ b/tutorial/99-delete-ordering-organization-components.yml
@@ -5,27 +5,27 @@
 - name: Delete components for an ordering organization
   hosts: localhost
   vars:
-    state: absent
-    organization_name: "{{ ordering_org_name }}"
+      state: absent
+      organization_name: "{{ ordering_org_name }}"
   vars_files:
-    - common-vars.yml
-    - ordering-org-vars.yml
+      - common-vars.yml
+      - ordering-org-vars.yml
   roles:
-    - hyperledger.fabric-ansible-collection.ordering_organization
+      - hyperledger.fabric_ansible_collection.ordering_organization
 
 - name: Remove imported components
   hosts: localhost
   vars_files:
-    - common-vars.yml
-    - ordering-org-vars.yml
+      - common-vars.yml
+      - ordering-org-vars.yml
   tasks:
-    - name: Remove imported organization
-      hyperledger.fabric-ansible-collection.external_organization:
-        api_endpoint: "{{ api_endpoint }}"
-        api_authtype: "{{ api_authtype }}"
-        api_key: "{{ api_key }}"
-        api_secret: "{{ api_secret | default(omit) }}"
-        api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
-        state: absent
-        name: "{{ org1_name }}"
-      when: import_export_used | default(false)
+      - name: Remove imported organization
+        hyperledger.fabric_ansible_collection.external_organization:
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+            state: absent
+            name: "{{ org1_name }}"
+        when: import_export_used | default(false)


### PR DESCRIPTION
The galaxy.yml file was changed at some point to rename the collection to `fabric_ansible_collection`:

https://github.com/hyperledger-labs/fabric-ansible-collection/blob/371e5665bc8c6f99ea4f648bedda7b8893c85aee/galaxy.yml#L6

However some of the roles and the tutorial playbooks referred to it with dashes instead of underscores, eg:

https://github.com/hyperledger-labs/fabric-ansible-collection/blob/371e5665bc8c6f99ea4f648bedda7b8893c85aee/roles/endorsing_organization/tasks/create.yml#L41

This meant locally built Ansible collections would not work.