### PR TITLE
Adding offline flag to ansible-lint

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -11,4 +11,8 @@ exclude_paths:
 
 skip_list:
     - risky-file-permissions
-    - 'fqcn-builtins'
+    - "fqcn-builtins"
+
+# Offline mode disables installation of requirements.yml and schema refreshing
+# 6.17.1 introduced a race condition bug with this noted workaround: https://github.com/ansible/ansible-lint/issues/3560#issuecomment-1590745951
+offline: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 #
 ansible
 ansible-doc-extractor
-ansible-lint==6.17.0
+ansible-lint
 flake8
 fabric-sdk-py
 openshift

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 #
 ansible
 ansible-doc-extractor
-ansible-lint
+ansible-lint==6.17.0
 flake8
 fabric-sdk-py
 openshift


### PR DESCRIPTION
- New 6.17.1 version of ansible-lint introduced a race condition bug with this workaround noted
- Race condition issue is noted in the ansible-lint repo: https://github.com/ansible/ansible-lint/issues/3560