### PR TITLE
Change Console APIs to v3

### DIFF
--- a/plugins/module_utils/certificate_authorities.py
+++ b/plugins/module_utils/certificate_authorities.py
@@ -41,7 +41,7 @@ class CertificateAuthorityException(Exception):
 
 class CertificateAuthority:
 
-    def __init__(self, name, api_url, operations_url, ca_url, ca_name, tlsca_name, pem, location):
+    def __init__(self, name, api_url, operations_url, ca_url, ca_name, tlsca_name, pem, location, msp):
         self.name = name
         self.api_url = api_url
         self.operations_url = operations_url
@@ -50,6 +50,7 @@ class CertificateAuthority:
         self.tlsca_name = tlsca_name
         self.pem = pem
         self.location = location
+        self.msp = msp
 
     def clone(self):
         return CertificateAuthority(
@@ -60,7 +61,8 @@ class CertificateAuthority:
             ca_name=self.ca_name,
             tlsca_name=self.tlsca_name,
             pem=self.pem,
-            location=self.location
+            location=self.location,
+            msp=self.msp
         )
 
     def equals(self, other):
@@ -72,7 +74,8 @@ class CertificateAuthority:
             self.ca_name == other.ca_name and
             self.tlsca_name == other.tlsca_name and
             self.pem == other.pem and
-            self.location == other.location
+            self.location == other.location and
+            self.msp == other.msp
         )
 
     def to_json(self):
@@ -86,7 +89,8 @@ class CertificateAuthority:
             tlsca_name=self.tlsca_name,
             pem=self.pem,
             tls_cert=self.pem,
-            location=self.location
+            location=self.location,
+            msp=self.msp
         )
 
     @staticmethod
@@ -99,7 +103,8 @@ class CertificateAuthority:
             ca_name=data['ca_name'],
             tlsca_name=data['tlsca_name'],
             pem=data['pem'],
-            location=data['location']
+            location=data['location'],
+            msp=data['msp']
         )
 
     def wait_for(self, timeout):

--- a/plugins/module_utils/ordering_services.py
+++ b/plugins/module_utils/ordering_services.py
@@ -24,7 +24,7 @@ from .msp_utils import convert_identity_to_msp_path
 
 class OrderingServiceNode:
 
-    def __init__(self, name, api_url, operations_url, grpcwp_url, msp_id, pem, tls_ca_root_cert, tls_cert, location, system_channel_id, cluster_id, cluster_name, client_tls_cert, server_tls_cert, consenter_proposal_fin):
+    def __init__(self, name, api_url, operations_url, grpcwp_url, msp_id, pem, tls_ca_root_cert, tls_cert, location, system_channel_id, cluster_id, cluster_name, client_tls_cert, server_tls_cert, consenter_proposal_fin, id, display_name, osnadmin_url, msp):
         self.name = name
         self.api_url = api_url
         self.operations_url = operations_url
@@ -40,6 +40,10 @@ class OrderingServiceNode:
         self.client_tls_cert = client_tls_cert
         self.server_tls_cert = server_tls_cert
         self.consenter_proposal_fin = consenter_proposal_fin
+        self.id = id
+        self.display_name = display_name
+        self.osnadmin_url = osnadmin_url
+        self.msp = msp
 
     def clone(self):
         return OrderingServiceNode(
@@ -57,7 +61,11 @@ class OrderingServiceNode:
             cluster_name=self.cluster_name,
             client_tls_cert=self.client_tls_cert,
             server_tls_cert=self.server_tls_cert,
-            consenter_proposal_fin=self.consenter_proposal_fin
+            consenter_proposal_fin=self.consenter_proposal_fin,
+            id=self.id,
+            display_name=self.display_name,
+            osnadmin_url=self.osnadmin_url,
+            msp=self.msp
         )
 
     def equals(self, other):
@@ -76,7 +84,11 @@ class OrderingServiceNode:
             self.cluster_name == other.cluster_name and
             self.client_tls_cert == other.client_tls_cert and
             self.server_tls_cert == other.server_tls_cert and
-            self.consenter_proposal_fin == other.consenter_proposal_fin
+            self.consenter_proposal_fin == other.consenter_proposal_fin and
+            self.id == other.id and
+            self.display_name == other.display_name and
+            self.osnadmin_url == other.osnadmin_url and
+            self.msp == other.msp
         )
 
     def to_json(self):
@@ -96,7 +108,11 @@ class OrderingServiceNode:
             cluster_name=self.cluster_name,
             client_tls_cert=self.client_tls_cert,
             server_tls_cert=self.server_tls_cert,
-            consenter_proposal_fin=self.consenter_proposal_fin
+            id=self.id,
+            display_name=self.display_name,
+            osnadmin_url=self.osnadmin_url,
+            consenter_proposal_fin=self.consenter_proposal_fin,
+            msp=self.msp
         )
 
     @staticmethod
@@ -116,7 +132,11 @@ class OrderingServiceNode:
             cluster_name=data['cluster_name'],
             client_tls_cert=data['client_tls_cert'],
             server_tls_cert=data['server_tls_cert'],
-            consenter_proposal_fin=data['consenter_proposal_fin']
+            consenter_proposal_fin=data['consenter_proposal_fin'],
+            id=data['id'],
+            display_name=data['display_name'],
+            osnadmin_url=data['osnadmin_url'],
+            msp=data['msp']
         )
 
     def wait_for(self, timeout):
@@ -259,7 +279,10 @@ class OrderingService:
     def to_json(self):
         nodes = list()
         for node in self.nodes:
-            nodes.append(node.to_json())
+            # remove nulls
+            node_dict = node.to_json()
+            node_nonulls = {k: v for k, v in node_dict.items() if v is not None}
+            nodes.append(node_nonulls)
         return nodes
 
     @staticmethod

--- a/plugins/module_utils/peers.py
+++ b/plugins/module_utils/peers.py
@@ -27,7 +27,7 @@ from .proto_utils import proto_to_json
 
 class Peer:
 
-    def __init__(self, name, api_url, operations_url, grpcwp_url, msp_id, pem, tls_ca_root_cert, tls_cert, location):
+    def __init__(self, name, api_url, operations_url, grpcwp_url, msp_id, pem, tls_ca_root_cert, tls_cert, location, msp):
         self.name = name
         self.api_url = api_url
         self.operations_url = operations_url
@@ -37,6 +37,7 @@ class Peer:
         self.tls_ca_root_cert = tls_ca_root_cert
         self.tls_cert = tls_cert
         self.location = location
+        self.msp = msp
 
     def clone(self):
         return Peer(
@@ -48,7 +49,8 @@ class Peer:
             pem=self.pem,
             tls_ca_root_cert=self.tls_ca_root_cert,
             tls_cert=self.tls_cert,
-            location=self.location
+            location=self.location,
+            msp=self.msp
         )
 
     def equals(self, other):
@@ -61,7 +63,8 @@ class Peer:
             self.pem == other.pem and
             self.tls_ca_root_cert == other.tls_ca_root_cert and
             self.tls_cert == other.tls_cert and
-            self.location == other.location
+            self.location == other.location and
+            self.msp == other.msp
         )
 
     def to_json(self):
@@ -75,7 +78,8 @@ class Peer:
             pem=self.pem,
             tls_ca_root_cert=self.tls_ca_root_cert,
             tls_cert=self.tls_cert,
-            location=self.location
+            location=self.location,
+            msp=self.msp
         )
 
     @staticmethod
@@ -89,7 +93,8 @@ class Peer:
             pem=data['pem'],
             tls_ca_root_cert=data['tls_ca_root_cert'],
             tls_cert=data['tls_cert'],
-            location=data['location']
+            location=data['location'],
+            msp=data['msp']
         )
 
     def wait_for(self, timeout):

--- a/plugins/modules/certificate_authority.py
+++ b/plugins/modules/certificate_authority.py
@@ -186,103 +186,103 @@ requirements: []
 EXAMPLES = '''
 - name: Create certificate authority
   hyperledger.fabric_ansible_collection.certificate_authority:
-    state: present
-    api_endpoint: https://console.example.org:32000
-    api_authtype: basic
-    api_key: xxxxxxxx
-    api_secret: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-    name: Org1 CA
-    config_override:
-      ca:
-        registry:
-          maxenrollments: -1
-          identities:
-          - name: admin
-            pass: adminpw
-            type: client
-            maxenrollments: -1
-            attrs:
-              hf.Registrar.Roles: "*"
-              hf.Registrar.DelegateRoles: "*"
-              hf.Revoker: true
-              hf.IntermediateCA: true
-              hf.GenCRL: true
-              hf.Registrar.Attributes: "*"
-              hf.AffiliationMgr: true
+      state: present
+      api_endpoint: https://console.example.org:32000
+      api_authtype: basic
+      api_key: xxxxxxxx
+      api_secret: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      name: Org1 CA
+      config_override:
+          ca:
+              registry:
+                  maxenrollments: -1
+              identities:
+                  - name: admin
+                    pass: adminpw
+                    type: client
+                    maxenrollments: -1
+                    attrs:
+                        hf.Registrar.Roles: "*"
+                        hf.Registrar.DelegateRoles: "*"
+                        hf.Revoker: true
+                        hf.IntermediateCA: true
+                        hf.GenCRL: true
+                        hf.Registrar.Attributes: "*"
+                        hf.AffiliationMgr: true
 
 - name: Create certificate authority with custom resources and storage
   hyperledger.fabric_ansible_collection.certificate_authority:
-    state: present
-    api_endpoint: https://console.example.org:32000
-    api_authtype: basic
-    api_key: xxxxxxxx
-    api_secret: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-    name: Org1 CA
-    config_override:
-      ca:
-        registry:
-          maxenrollments: -1
-          identities:
-          - name: admin
-            pass: adminpw
-            type: client
-            maxenrollments: -1
-            attrs:
-              hf.Registrar.Roles: "*"
-              hf.Registrar.DelegateRoles: "*"
-              hf.Revoker: true
-              hf.IntermediateCA: true
-              hf.GenCRL: true
-              hf.Registrar.Attributes: "*"
-              hf.AffiliationMgr: true
-    resources:
-      ca:
-        requests:
-          cpu: 200m
-          memory: 400M
-    storage:
-      ca:
-        size: 40Gi
-        class: ibmc-file-gold
+      state: present
+      api_endpoint: https://console.example.org:32000
+      api_authtype: basic
+      api_key: xxxxxxxx
+      api_secret: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      name: Org1 CA
+      config_override:
+          ca:
+              registry:
+                  maxenrollments: -1
+                  identities:
+                      - name: admin
+                        pass: adminpw
+                        type: client
+                        maxenrollments: -1
+                        attrs:
+                            hf.Registrar.Roles: "*"
+                            hf.Registrar.DelegateRoles: "*"
+                            hf.Revoker: true
+                            hf.IntermediateCA: true
+                            hf.GenCRL: true
+                            hf.Registrar.Attributes: "*"
+                            hf.AffiliationMgr: true
+          resources:
+              ca:
+                  requests:
+                      cpu: 200m
+                      memory: 400M
+          storage:
+              ca:
+                  size: 40Gi
+                  class: ibmc-file-gold
 
 - name: Create certificate authority that uses an HSM
   hyperledger.fabric_ansible_collection.certificate_authority:
-    state: present
-    api_endpoint: https://console.example.org:32000
-    api_authtype: basic
-    api_key: xxxxxxxx
-    api_secret: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-    name: Org1 CA
-    config_override:
-      ca:
-        registry:
-          maxenrollments: -1
-          identities:
-          - name: admin
-            pass: adminpw
-            type: client
-            maxenrollments: -1
-            attrs:
-              hf.Registrar.Roles: "*"
-              hf.Registrar.DelegateRoles: "*"
-              hf.Revoker: true
-              hf.IntermediateCA: true
-              hf.GenCRL: true
-              hf.Registrar.Attributes: "*"
-              hf.AffiliationMgr: true
-    hsm:
-      pkcs11endpoint: tcp://pkcs11-proxy.example.org:2345
-      label: Org1 CA label
-      pin: 12345678
+      state: present
+      api_endpoint: https://console.example.org:32000
+      api_authtype: basic
+      api_key: xxxxxxxx
+      api_secret: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      name: Org1 CA
+      config_override:
+          ca:
+              registry:
+              maxenrollments: -1
+              identities:
+                  - name: admin
+                    pass: adminpw
+                    type: client
+                    maxenrollments: -1
+                    attrs:
+                        hf.Registrar.Roles: "*"
+                        hf.Registrar.DelegateRoles: "*"
+                        hf.Revoker: true
+                        hf.IntermediateCA: true
+                        hf.GenCRL: true
+                        hf.Registrar.Attributes: "*"
+                        hf.AffiliationMgr: true
+      hsm:
+          pkcs11endpoint: tcp://pkcs11-proxy.example.org:2345
+          label: Org1 CA label
+          pin: 12345678
 
 - name: Destroy certificate authority
   hyperledger.fabric_ansible_collection.certificate_authority:
-    state: absent
-    api_endpoint: https://console.example.org:32000
-    api_authtype: basic
-    api_key: xxxxxxxx
-    api_secret: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-    name: Org1 CA
+      state: absent
+      api_endpoint: https://console.example.org:32000
+      api_authtype: basic
+      api_key: xxxxxxxx
+      api_secret: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      name: Org1 CA
 '''
 
 RETURN = '''

--- a/plugins/modules/chaincode_list_info.py
+++ b/plugins/modules/chaincode_list_info.py
@@ -113,8 +113,6 @@ EXAMPLES = '''
     identity: Org1 Admin.json
     msp_id: Org1MSP
     channel: mychannel
-
-
 '''
 
 RETURN = '''

--- a/plugins/modules/external_certificate_authority.py
+++ b/plugins/modules/external_certificate_authority.py
@@ -220,7 +220,13 @@ def main():
             location=dict(type='str'),
             pem=dict(type='str'),
             tls_cert=dict(type='str'),
-            type=dict(type='str')
+            type=dict(type='str'),
+            cluster_type=dict(type='str', default=None),
+            console_type=dict(type='str', default=None),
+            display_name=dict(type='str', default=None),
+            id=dict(type='str', default=None),
+            msp=dict(type='dict', default=None),
+            scheme_version=dict(type='str', default=None)
         ))
     )
     required_if = [
@@ -287,9 +293,8 @@ def main():
             display_name=name,
             api_url=certificate_authority_definition['api_url'],
             operations_url=certificate_authority_definition['operations_url'],
-            ca_name=certificate_authority_definition['ca_name'],
-            tlsca_name=certificate_authority_definition['tlsca_name'],
             tls_cert=certificate_authority_definition['tls_cert'] or certificate_authority_definition['pem'],
+            msp=certificate_authority_definition['msp']
         )
 
         # Handle appropriately based on state.

--- a/plugins/modules/external_ordering_service.py
+++ b/plugins/modules/external_ordering_service.py
@@ -275,7 +275,15 @@ def main():
             cluster_id=dict(type='str'),
             cluster_name=dict(type='str'),
             type=dict(type='str'),
-            consenter_proposal_fin=dict(type='bool')
+            consenter_proposal_fin=dict(type='bool'),
+            cluster_type=dict(type='str', default=None),
+            console_type=dict(type='str', default=None),
+            display_name=dict(type='str', default=None),
+            id=dict(type='str', default=None),
+            msp=dict(type='dict', default=None),
+            scheme_version=dict(type='str', default=None),
+            imported=dict(type='bool', default=None),
+            osnadmin_url=dict(type='str', default=None)
         ))
     )
     required_if = [
@@ -365,12 +373,13 @@ def main():
                 operations_url=ordering_service_node['operations_url'],
                 grpcwp_url=ordering_service_node['grpcwp_url'],
                 msp_id=ordering_service_node['msp_id'],
-                tls_ca_root_cert=ordering_service_node['tls_ca_root_cert'] or ordering_service_node['pem'],
                 system_channel_id=ordering_service_node['system_channel_id'],
                 client_tls_cert=ordering_service_node['client_tls_cert'],
                 server_tls_cert=ordering_service_node['server_tls_cert'],
                 cluster_id=ordering_service_node['cluster_id'],
-                cluster_name=ordering_service_node['cluster_name']
+                cluster_name=ordering_service_node['cluster_name'],
+                msp=ordering_service_node['msp'],
+                osnadmin_url=ordering_service_node['osnadmin_url']
             )
 
             # HACK: delete null properties.
@@ -378,6 +387,8 @@ def main():
                 del expected_ordering_service_node['client_tls_cert']
             if expected_ordering_service_node['server_tls_cert'] is None:
                 del expected_ordering_service_node['server_tls_cert']
+            if expected_ordering_service_node['osnadmin_url'] is None:
+                del expected_ordering_service_node['osnadmin_url']
 
             # Determine if it exists.
             ordering_service_node = console.get_component_by_display_name('fabric-orderer', ordering_service_node['name'])

--- a/plugins/modules/external_ordering_service_node.py
+++ b/plugins/modules/external_ordering_service_node.py
@@ -273,7 +273,15 @@ def main():
             cluster_id=dict(type='str'),
             cluster_name=dict(type='str'),
             type=dict(type='str'),
-            consenter_proposal_fin=dict(type='bool')
+            consenter_proposal_fin=dict(type='bool'),
+            cluster_type=dict(type='str', default=None),
+            console_type=dict(type='str', default=None),
+            display_name=dict(type='str', default=None),
+            id=dict(type='str', default=None),
+            msp=dict(type='dict', default=None),
+            scheme_version=dict(type='str', default=None),
+            imported=dict(type='bool', default=None),
+            osnadmin_url=dict(type='str', default=None)
         ))
     )
     required_if = [
@@ -342,12 +350,13 @@ def main():
             operations_url=ordering_service_node_definition['operations_url'],
             grpcwp_url=ordering_service_node_definition['grpcwp_url'],
             msp_id=ordering_service_node_definition['msp_id'],
-            tls_ca_root_cert=ordering_service_node_definition['tls_ca_root_cert'] or ordering_service_node_definition['pem'],
             system_channel_id=ordering_service_node_definition['system_channel_id'],
             client_tls_cert=ordering_service_node_definition['client_tls_cert'],
             server_tls_cert=ordering_service_node_definition['server_tls_cert'],
             cluster_id=ordering_service_node_definition['cluster_id'],
-            cluster_name=ordering_service_node_definition['cluster_name']
+            cluster_name=ordering_service_node_definition['cluster_name'],
+            msp=ordering_service_node_definition['msp'],
+            osnadmin_url=ordering_service_node_definition['osnadmin_url']
         )
 
         # HACK: delete null properties.
@@ -355,6 +364,8 @@ def main():
             del expected_ordering_service_node['client_tls_cert']
         if expected_ordering_service_node['server_tls_cert'] is None:
             del expected_ordering_service_node['server_tls_cert']
+        if expected_ordering_service_node['osnadmin_url'] is None:
+            del expected_ordering_service_node['osnadmin_url']
 
         # Handle appropriately based on state.
         changed = False

--- a/plugins/modules/external_organization.py
+++ b/plugins/modules/external_organization.py
@@ -440,7 +440,11 @@ def main():
                 organizational_unit_identifier=dict(type='str')
             )),
             host_url=dict(type='str', default=None),
-            type=dict(type='str')
+            type=dict(type='str'),
+            display_name=dict(type='str', default=None),
+            id=dict(type='str', default=None),
+            imported=dict(type='bool', default=None),
+            scheme_version=dict(type='str', default=None)
         ))
     )
     required_if = [
@@ -496,7 +500,8 @@ def main():
             tls_intermediate_certs=organization_definition['tls_intermediate_certs'],
             fabric_node_ous=organization_definition['fabric_node_ous'],
             organizational_unit_identifiers=organization_definition['organizational_unit_identifiers'],
-            host_url=organization_definition['host_url']
+            host_url=organization_definition['host_url'],
+            id=organization_definition['id'],
         )
 
         # Handle appropriately based on state.

--- a/plugins/modules/external_peer.py
+++ b/plugins/modules/external_peer.py
@@ -222,7 +222,13 @@ def main():
             tls_ca_root_cert=dict(type='str'),
             tls_cert=dict(type='str'),
             location=dict(type='str'),
-            type=dict(type='str')
+            type=dict(type='str'),
+            cluster_type=dict(type='str', default=None),
+            console_type=dict(type='str', default=None),
+            display_name=dict(type='str', default=None),
+            id=dict(type='str', default=None),
+            msp=dict(type='dict', default=None),
+            scheme_version=dict(type='str', default=None)
         ))
     )
     required_if = [
@@ -291,7 +297,7 @@ def main():
             operations_url=peer_definition['operations_url'],
             grpcwp_url=peer_definition['grpcwp_url'],
             msp_id=peer_definition['msp_id'],
-            tls_ca_root_cert=peer_definition['tls_ca_root_cert'] or peer_definition['pem'],
+            msp=peer_definition['msp']
         )
 
         # Handle appropriately based on state.

--- a/plugins/modules/peer.py
+++ b/plugins/modules/peer.py
@@ -439,65 +439,58 @@ peer:
 '''
 
 
-def get_config(console, module):
+def get_crypto(console, module):
 
-    # See if the user provided their own configuration.
-    config = module.params['config']
-    if config is not None:
-        return config
+    # Get the crypto configuration.
+    return {'enrollment': get_crypto_enrollment_config(console, module)}
 
-    # Otherwise, provide an enrollment configuration.
+
+def get_crypto_enrollment_config(console, module):
+
+    # Get the crypto configuration.
     return {
-        'enrollment': get_enrollment_config(console, module)
+        'component': get_crypto_enrollment_component_config(console, module),
+        'ca': get_crypto_enrollment_ca_config(console, module),
+        'tlsca': get_crypto_enrollment_tlsca_config(console, module),
     }
 
 
-def get_enrollment_config(console, module):
-
-    # Get the enrollment configuration.
-    return {
-        'component': get_enrollment_component_config(console, module),
-        'tls': get_enrollment_tls_config(console, module),
-    }
-
-
-def get_enrollment_component_config(console, module):
-
-    # Get the enrollment configuration for the peers MSP.
-    certificate_authority = get_certificate_authority_by_module(console, module)
-    certificate_authority_url = urllib.parse.urlsplit(certificate_authority.api_url)
-    enrollment_id = module.params['enrollment_id']
-    enrollment_secret = module.params['enrollment_secret']
+def get_crypto_enrollment_component_config(console, module):
     admins = module.params['admins']
-    return {
-        'cahost': certificate_authority_url.hostname,
-        'caport': str(certificate_authority_url.port),
-        'caname': certificate_authority.ca_name,
-        'catls': {
-            'cacert': certificate_authority.pem
-        },
-        'enrollid': enrollment_id,
-        'enrollsecret': enrollment_secret,
-        'admincerts': admins
-    }
+    return {'admincerts': admins}
 
 
-def get_enrollment_tls_config(console, module):
+def get_crypto_enrollment_ca_config(console, module):
 
-    # Get the enrollment configuration for the peers TLS.
+    # Get the enrollment configuration for the ordering services MSP.
     certificate_authority = get_certificate_authority_by_module(console, module)
     certificate_authority_url = urllib.parse.urlsplit(certificate_authority.api_url)
     enrollment_id = module.params['enrollment_id']
     enrollment_secret = module.params['enrollment_secret']
     return {
-        'cahost': certificate_authority_url.hostname,
-        'caport': str(certificate_authority_url.port),
-        'caname': certificate_authority.tlsca_name,
-        'catls': {
-            'cacert': certificate_authority.pem
-        },
-        'enrollid': enrollment_id,
-        'enrollsecret': enrollment_secret
+        'host': certificate_authority_url.hostname,
+        'port': str(certificate_authority_url.port),
+        'name': certificate_authority.ca_name,
+        'tls_cert': certificate_authority.pem,
+        'enroll_id': enrollment_id,
+        'enroll_secret': enrollment_secret,
+    }
+
+
+def get_crypto_enrollment_tlsca_config(console, module):
+
+    # Get the enrollment configuration for the ordering services TLS.
+    certificate_authority = get_certificate_authority_by_module(console, module)
+    certificate_authority_url = urllib.parse.urlsplit(certificate_authority.api_url)
+    enrollment_id = module.params['enrollment_id']
+    enrollment_secret = module.params['enrollment_secret']
+    return {
+        'host': certificate_authority_url.hostname,
+        'port': str(certificate_authority_url.port),
+        'name': certificate_authority.tlsca_name,
+        'tls_cert': certificate_authority.pem,
+        'enroll_id': enrollment_id,
+        'enroll_secret': enrollment_secret,
     }
 
 
@@ -519,7 +512,7 @@ def main():
         enrollment_id=dict(type='str'),
         enrollment_secret=dict(type='str', no_log=True),
         admins=dict(type='list', elements='str', aliases=['admin_certificates']),
-        config=dict(type='dict'),
+        crypto=dict(type='dict'),
         config_override=dict(type='dict', default=dict()),
         resources=dict(type='dict', default=dict(), options=dict(
             peer=dict(type='dict', default=dict(), options=dict(
@@ -581,7 +574,7 @@ def main():
     actual_params = _load_params()
     if actual_params.get('state', 'present') == 'present':
         required_one_of = [
-            ['certificate_authority', 'config']
+            ['certificate_authority', 'crypto']
         ]
     else:
         required_one_of = []
@@ -591,7 +584,7 @@ def main():
         ['certificate_authority', 'admins']
     ]
     mutually_exclusive = [
-        ['certificate_authority', 'config']
+        ['certificate_authority', 'crypto']
     ]
     module = BlockchainModule(
         argument_spec=argument_spec,
@@ -715,7 +708,7 @@ def main():
                 del expected_peer['storage']
 
             # Get the config.
-            expected_peer['config'] = get_config(console, module)
+            expected_peer['crypto'] = get_crypto(console, module)
 
             # We should only send dind resources if the peer is running Fabric v1.4.
             # We should only send chaincodelauncher resources if the peer is running Fabric v2.x.
@@ -799,10 +792,10 @@ def main():
             # and it does not support this feature.
             expected_admins = module.params['admins']
             if not expected_admins:
-                config = module.params['config']
-                if config:
+                crypto = module.params['crypto']
+                if crypto:
                     for config_type in ['enrollment', 'msp']:
-                        expected_admins = config.get(config_type, dict()).get('component', dict()).get('admincerts', None)
+                        expected_admins = crypto.get(config_type, dict()).get('component', dict()).get('admincerts', None)
                         if expected_admins:
                             break
             if expected_admins:


### PR DESCRIPTION
This is a change to move the ansible collection from v2 to v3 console APIs. 

This change also provides interoperability with the Fabric Operations console.   Export files and be interchanged between ansible managed console and Fabric Operations console.