### PR TITLE
Adding Restriction on Security Context to restrict unshare calls

### DIFF
--- a/roles/fabric_operator_crds/templates/openshift/manager/hlf-operator-manager.yaml.j2
+++ b/roles/fabric_operator_crds/templates/openshift/manager/hlf-operator-manager.yaml.j2
@@ -110,6 +110,8 @@ spec:
               value: "fabric-operator"
             - name: CLUSTERTYPE
               value: OPENSHIFT
+            - name: IBPOPERATOR_CONSOLE_APPLYNETWORKPOLICY
+              value: "true"
           resources:
             requests:
               cpu: 10m

--- a/roles/fabric_operator_crds/templates/openshift/security_context_constraints.yml.j2
+++ b/roles/fabric_operator_crds/templates/openshift/security_context_constraints.yml.j2
@@ -11,8 +11,8 @@ allowHostIPC: true
 allowHostNetwork: true
 allowHostPID: true
 allowHostPorts: true
-allowPrivilegeEscalation: true
-allowPrivilegedContainer: true
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
 allowedCapabilities:
 - NET_BIND_SERVICE
 - CHOWN
@@ -31,6 +31,8 @@ readOnlyRootFilesystem: false
 requiredDropCapabilities: null
 runAsUser:
   type: RunAsAny
+seccompProfiles:
+- runtime/default
 seLinuxContext:
   type: RunAsAny
 supplementalGroups:


### PR DESCRIPTION
As part of the pentest, we have identified an issue in the openshift cluster SCC. 