### PR TITLE
Solve error related to running the ansible collections when using the default docker entrypoint linked to ibp-user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,6 @@ tests/output
 
 # mac gumph
 .DS_Store
+
+# intellij
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,7 @@ COPY --from=builder /home/hlf-user/.ansible /home/hlf-user/.ansible
 COPY --from=fabric /go/src/github.com/hyperledger/fabric/build/bin /opt/fabric/bin
 COPY --from=fabric /go/src/github.com/hyperledger/fabric/sampleconfig /opt/fabric/config
 COPY docker/docker-entrypoint.sh /
+COPY docker/docker-entrypoint-opensource-stack.sh /
 RUN mkdir /home/hlf-user/.kube
 ENV FABRIC_CFG_PATH=/opt/fabric/config
 ENV PATH=/opt/fabric/bin:/home/hlf-user/.local/bin:$PATH

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The choice will depend on what context you want to use ansible in.
   docker run --entrypoint docker/docker-entrypoint-opensource-stack.sh --rm -u $(id -u) -v /path/to/playbooks:/playbooks ghcr.io/hyperledger-labs/fabric-ansible:sha-c9330b9 ansible-playbook /playbooks/playbook.yml
   ```
 
-- If you are using minikube with docker drive you need to specify the docker minikube network:
+- If you are using minikube with docker driver you need to specify the docker minikube network:
   ```shell
   docker run --network minikube --entrypoint docker/docker-entrypoint-opensource-stack.sh --rm -u $(id -u) -v /path/to/playbooks:/playbooks ghcr.io/hyperledger-labs/fabric-ansible:sha-c9330b9 ansible-playbook /playbooks/playbook.yml
   ```

--- a/README.md
+++ b/README.md
@@ -49,6 +49,15 @@ The choice will depend on what context you want to use ansible in.
   docker pull ghcr.io/hyperledger-labs/fabric-ansible:sha-c9330b9
   docker run --rm -u $(id -u) -v /path/to/playbooks:/playbooks ghcr.io/hyperledger-labs/fabric-ansible:sha-c9330b9 ansible-playbook /playbooks/playbook.yml
   ```
+- For running in environments like ubuntu that does not have the ibp-user (open source stack) you need to override the docker entrypoint:
+  ```shell
+  docker run --entrypoint docker/docker-entrypoint-opensource-stack.sh --rm -u $(id -u) -v /path/to/playbooks:/playbooks ghcr.io/hyperledger-labs/fabric-ansible:sha-c9330b9 ansible-playbook /playbooks/playbook.yml
+  ```
+
+- If you are using minikube with docker drive you need to specify the docker minikube network:
+  ```shell
+  docker run --network minikube --entrypoint docker/docker-entrypoint-opensource-stack.sh --rm -u $(id -u) -v /path/to/playbooks:/playbooks ghcr.io/hyperledger-labs/fabric-ansible:sha-c9330b9 ansible-playbook /playbooks/playbook.yml
+  ```
 
 - If you are using github actions for CI/CD there is a [github action](https://github.com/hyperledgendary/fabric-cloud-infrastructure/tree/main/fabric-ansible-action) that uses the same docker image as the basis.
   For example; note this action needs to still be published. In the interim please copy this to your own repository

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The choice will depend on what context you want to use ansible in.
 
 - If you are using minikube with docker driver you need to specify the docker minikube network:
   ```shell
-  docker run --network minikube --entrypoint docker/docker-entrypoint-opensource-stack.sh --rm -u $(id -u) -v /path/to/playbooks:/playbooks ghcr.io/hyperledger-labs/fabric-ansible:sha-c9330b9 ansible-playbook /playbooks/playbook.yml
+  docker run --network minikube --entrypoint /docker-entrypoint-opensource-stack.sh --rm -u $(id -u) -v /path/to/playbooks:/playbooks ghcr.io/hyperledger-labs/fabric-ansible:sha-c9330b9 ansible-playbook /playbooks/playbook.yml
   ```
 
 - If you are using github actions for CI/CD there is a [github action](https://github.com/hyperledgendary/fabric-cloud-infrastructure/tree/main/fabric-ansible-action) that uses the same docker image as the basis.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The choice will depend on what context you want to use ansible in.
   ```
 - For running in environments like ubuntu that does not have the ibp-user so, you may need to override the docker entrypoint:
   ```shell
-  docker run --entrypoint docker/docker-entrypoint-opensource-stack.sh --rm -u $(id -u) -v /path/to/playbooks:/playbooks ghcr.io/hyperledger-labs/fabric-ansible:sha-c9330b9 ansible-playbook /playbooks/playbook.yml
+  docker run --entrypoint /docker-entrypoint-opensource-stack.sh --rm -u $(id -u) -v /path/to/playbooks:/playbooks ghcr.io/hyperledger-labs/fabric-ansible:sha-c9330b9 ansible-playbook /playbooks/playbook.yml
   ```
 
 - If you are using minikube with docker driver you need to specify the docker minikube network:

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The choice will depend on what context you want to use ansible in.
   docker pull ghcr.io/hyperledger-labs/fabric-ansible:sha-c9330b9
   docker run --rm -u $(id -u) -v /path/to/playbooks:/playbooks ghcr.io/hyperledger-labs/fabric-ansible:sha-c9330b9 ansible-playbook /playbooks/playbook.yml
   ```
-- For running in environments like ubuntu that does not have the ibp-user (open source stack) you need to override the docker entrypoint:
+- For running in environments like ubuntu that does not have the ibp-user so, you may need to override the docker entrypoint:
   ```shell
   docker run --entrypoint docker/docker-entrypoint-opensource-stack.sh --rm -u $(id -u) -v /path/to/playbooks:/playbooks ghcr.io/hyperledger-labs/fabric-ansible:sha-c9330b9 ansible-playbook /playbooks/playbook.yml
   ```

--- a/docker/docker-entrypoint-opensource-stack.sh
+++ b/docker/docker-entrypoint-opensource-stack.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+set -euo pipefail
+
+# If this image is run with -u <random UID>, as happens on Red Hat OpenShift, then
+# the user is not in the /etc/passwd file. This causes Ansible to fail, so we need
+# to add the user to /etc/passwd now before Ansible runs.
+if ! whoami &> /dev/null; then
+    sed '/hlf-user/d' /etc/passwd > /tmp/passwd
+    cat /tmp/passwd > /etc/passwd
+    rm -f /tmp/passwd
+    echo "hlf-user:x:$(id -u):0::/home/hlf-user:/bin/bash" >> /etc/passwd
+    export HOME=/home/hlf-user
+fi
+
+# Run a shell or the specified command.
+if [ $# -eq 0 ]; then
+    exec /bin/bash
+else
+    exec "$@"
+fi

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -168,7 +168,7 @@ You can run a playbook using this Docker image, by volume mounting the playbook 
 
 Note that the UID flag ``-u $(id -u)`` ensures that Ansible can write connection profile and identity files to the volume mount.
 
-Note that the --entrypoint docker/docker-entrypoint-opensource-stack.sh is needed because Dockerfile is using another user: hlf-user
+Note that the --entrypoint /docker-entrypoint-opensource-stack.sh is needed because Dockerfile is using another user: hlf-user
 
 The Docker image is supported for use in Docker, Kubernetes, and Red Hat OpenShift.
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -164,7 +164,7 @@ You can run a playbook using this Docker image, by volume mounting the playbook 
 
 ::
 
-    docker run --rm --entrypoint docker/docker-entrypoint-opensource-stack.sh -u $(id -u) -v /path/to/playbooks:/playbooks docker pull ghcr.io/hyperledger-labs/fabric-ansible:latest /playbooks/playbook.yml
+    docker run --rm --entrypoint /docker-entrypoint-opensource-stack.sh -u $(id -u) -v /path/to/playbooks:/playbooks docker pull ghcr.io/hyperledger-labs/fabric-ansible:latest /playbooks/playbook.yml
 
 Note that the UID flag ``-u $(id -u)`` ensures that Ansible can write connection profile and identity files to the volume mount.
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -164,9 +164,11 @@ You can run a playbook using this Docker image, by volume mounting the playbook 
 
 ::
 
-    docker run --rm -u $(id -u) -v /path/to/playbooks:/playbooks docker pull ghcr.io/hyperledger-labs/fabric-ansible:latest /playbooks/playbook.yml
+    docker run --rm --entrypoint docker/docker-entrypoint-opensource-stack.sh -u $(id -u) -v /path/to/playbooks:/playbooks docker pull ghcr.io/hyperledger-labs/fabric-ansible:latest /playbooks/playbook.yml
 
 Note that the UID flag ``-u $(id -u)`` ensures that Ansible can write connection profile and identity files to the volume mount.
+
+Note that the --entrypoint docker/docker-entrypoint-opensource-stack.sh is needed because Dockerfile is using another user: hlf-user
 
 The Docker image is supported for use in Docker, Kubernetes, and Red Hat OpenShift.
 


### PR DESCRIPTION
Related to issue: #43

Added new docker entrypoint to be able to override the current one.

The error happens when we follow the documentation from the public repository for running the playbooks with the docker image:

```bash
docker pull ghcr.io/hyperledger-labs/fabric-ansible:sha-c9330b9
docker run --rm -u $(id -u) -v /path/to/playbooks:/playbooks ghcr.io/hyperledger-labs/fabric-ansible:sha-c9330b9 ansible-playbook /playbooks/playbook.yml
```
Error:

```bash
Traceback (most recent call last):
  File "/home/hlf-user/.local/bin/ansible-playbook", line 5, in <module>
    from ansible.cli.playbook import main
ModuleNotFoundError: No module named 'ansible' 
```