### PR TITLE
remove unsupported flags for init chaincode

### DIFF
--- a/plugins/module_utils/peers.py
+++ b/plugins/module_utils/peers.py
@@ -401,17 +401,9 @@ class PeerConnection:
         else:
             raise Exception(f'Failed to commit chaincode on peer: {process.stdout} {process.stderr}')
 
-    def init_chaincode(self, channel, msp_ids, name, initJsonStr, endorsement_policy_ref, endorsement_policy, endorsement_plugin, validation_plugin, timeout, orderer):
+    def init_chaincode(self, channel, msp_ids, name, initJsonStr, timeout, orderer):
         env = self._get_environ()
         args = ['peer', 'chaincode', 'invoke', '-C', channel, '-n', name, '--isInit', '--ctor', initJsonStr, '--waitForEventTimeout', str(timeout) + "s"]
-        if endorsement_policy_ref:
-            args.extend(['--channel-config-policy', endorsement_policy_ref])
-        elif endorsement_policy:
-            args.extend(['--signature-policy', endorsement_policy])
-        if endorsement_plugin:
-            args.extend(['--endorsement-plugin', endorsement_plugin])
-        if validation_plugin:
-            args.extend(['--validation-plugin', validation_plugin])
         args.extend(self._get_anchor_peers(channel, msp_ids))
         args.extend(self._get_ordering_service(channel, orderer))
         process = self._run_command(args, env)

--- a/plugins/modules/committed_chaincode.py
+++ b/plugins/modules/committed_chaincode.py
@@ -405,7 +405,7 @@ def main():
                 peer_connection.commit_chaincode(channel, msp_ids, name, version, sequence, endorsement_policy_ref, endorsement_policy, endorsement_plugin, validation_plugin, init_required, collections_config, timeout, orderer)
                 changed = True
                 if init_required:
-                    peer_connection.init_chaincode(channel, msp_ids, name, initJsonStr, endorsement_policy_ref, endorsement_policy, endorsement_plugin, validation_plugin, timeout, orderer)
+                    peer_connection.init_chaincode(channel, msp_ids, name, initJsonStr, timeout, orderer)
 
         # Return the committed chaincode.
         return module.exit_json(changed=changed, committed_chaincode=dict(channel=channel, name=name, version=version, sequence=sequence, endorsement_policy_ref=endorsement_policy_ref, endorsement_policy=endorsement_policy, endorsement_plugin=endorsement_plugin, validation_plugin=validation_plugin, init_required=init_required, collections_config=collections_config))


### PR DESCRIPTION
The original code leads to an error when init_required is true:

```
Failed to init legacy chaincode on peer:  Error: unknown flag: --endorsement-plugin
```

See also: https://hyperledger-fabric.readthedocs.io/en/release-2.5/commands/peerchaincode.html#peer-chaincode-invoke