### PR TITLE
Add fabproxy removal example

### DIFF
--- a/examples/fabproxy-removal/01-migrate-all-ca-addresses.yml
+++ b/examples/fabproxy-removal/01-migrate-all-ca-addresses.yml
@@ -1,0 +1,37 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+- name: Renew the TLS Certificate for all Certificate Authorities and Associated Nodes
+  hosts: localhost
+  vars_files:
+      - common-vars.yml
+  tasks:
+      - name: Get the ALL Certificate Authorities
+        hyperledger.fabric_ansible_collection.certificate_authority_list_info:
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+        register: result
+
+      - name: Store the Certificate Authorities in a file
+        copy:
+            content: "{{ result.certificate_authorities | to_nice_json }}"
+            dest: "All_CAs.json"
+
+      - name: List Certificate Authorities
+        debug: "msg='Found Certificate Authority {{ certificate_authority.name}}'"
+        loop: "{{ result.certificate_authorities }}"
+        loop_control:
+            loop_var: certificate_authority
+            label: "{{ certificate_authority.name }}"
+
+      - name: Update CA Metadata
+        include_tasks: tasks/01-update-ca-metadata.yml
+        loop: "{{ result.certificate_authorities }}"
+        loop_control:
+          loop_var: certificate_authority
+          label: "{{ certificate_authority.name }}"
+        when: certificate_authority.imported == False

--- a/examples/fabproxy-removal/02-update-associated-nodes.yml
+++ b/examples/fabproxy-removal/02-update-associated-nodes.yml
@@ -1,0 +1,31 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+- name: Renew the TLS Certificate for all Certificate Authorities and Associated Nodes
+  hosts: localhost
+  vars_files:
+      - common-vars.yml
+  tasks:
+      - name: Get the ALL Certificate Authorities
+        hyperledger.fabric_ansible_collection.certificate_authority_list_info:
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+        register: result
+
+      - name: List Certificate Authorities
+        debug: "msg='Found Certificate Authority {{ certificate_authority.name}}'"
+        loop: "{{ result.certificate_authorities }}"
+        loop_control:
+            loop_var: certificate_authority
+            label: "{{ certificate_authority.name }}"
+
+      - name: Renew TLS Certificates for Certificate Authorities
+        include_tasks: tasks/02-create-crypto-update.yml
+        loop: "{{ result.certificate_authorities }}"
+        loop_control:
+            loop_var: certificate_authority
+            label: "{{ certificate_authority.name }}"

--- a/examples/fabproxy-removal/03-migrate-peer-and-imported-addresses.yml
+++ b/examples/fabproxy-removal/03-migrate-peer-and-imported-addresses.yml
@@ -1,0 +1,31 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+- name: Renew the TLS Certificate for all Certificate Authorities and Associated Nodes
+  hosts: localhost
+  vars_files:
+      - common-vars.yml
+  tasks:
+      - name: Get the ALL Certificate Authorities
+        hyperledger.fabric_ansible_collection.certificate_authority_list_info:
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+        register: result
+
+      - name: List Certificate Authorities
+        debug: "msg='Found Certificate Authority {{ certificate_authority.name}}'"
+        loop: "{{ result.certificate_authorities }}"
+        loop_control:
+            loop_var: certificate_authority
+            label: "{{ certificate_authority.name }}"
+
+      - name: Get Peers for the CA
+        include_tasks: tasks/03-get-all-nodes-for-ca.yml
+        loop: "{{ result.certificate_authorities }}"
+        loop_control:
+            loop_var: certificate_authority
+            label: "{{ certificate_authority.name }}"

--- a/examples/fabproxy-removal/04-migrate-ordering-node-addresses.yml
+++ b/examples/fabproxy-removal/04-migrate-ordering-node-addresses.yml
@@ -1,0 +1,85 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+- name: Migrate Ordering Service Node
+  hosts: localhost
+  vars_files:
+      - common-vars.yml
+      - channels.yml
+  tasks:
+
+      - name: Reenroll Ordering Service Node "{{ ordering_service_node_name }}" TLS
+        hyperledger.fabric_ansible_collection.ordering_service_node_action:
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            name: "{{ ordering_service_node_name }}"
+            action: 'reenroll'
+            type: 'tls_cert'
+        register: result
+
+      - name: Fail if the Certificate Authority did not accept the message
+        fail:
+            msg: result.response
+        when: not result.accepted
+
+      - name: Temporarily change Ordering Service Node "{{ ordering_service_node_name }}" to use the new URLs and record settings
+        hyperledger.fabric_ansible_collection.ordering_service_node_metadata:
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+            name: "{{ ordering_service_node_name }}"
+            preferred_url: "{{ preferred_url_os }}"
+        register: ordering_node_new_url
+
+      - name: Change Ordering Node "{{ ordering_service_node_name }}" to use the legacy URLs
+        hyperledger.fabric_ansible_collection.ordering_service_node_metadata:
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+            name: "{{ ordering_service_node_name }}"
+            preferred_url: "{{ preferred_url_legacy }}"
+        register: ordering_node_legacy_url
+
+      - name: Store the ordering service node to a file
+        copy:
+            content: "{{ ordering_node_new_url.ordering_service_node | to_nice_json }}"
+            dest: "{{ ordering_service_node_name }}.json"
+
+      - name: Remove the previous channels directory if it exists
+        ansible.builtin.file:
+            path: channels
+            state: absent
+
+      - name: Remove the previous completed channels
+        ansible.builtin.file:
+            path: completed_channels.txt
+            state: absent
+
+      - name: Update channels
+        include_tasks: tasks/04-update-channel.yml
+        loop: "{{ channel_names }}"
+        loop_control:
+            loop_var: channel_name
+
+      - name: Change Ordering Service Node "{{ ordering_service_node_name }}" to use the new URLs
+        hyperledger.fabric_ansible_collection.ordering_service_node_metadata:
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+            name: "{{ ordering_service_node_name }}"
+            preferred_url: "{{ preferred_url_os }}"
+        when: not (dry_run | bool)
+
+      - name: Warn if dry run
+        debug:
+            msg: Dry run, not signing or applying channel configuration update
+        when: (dry_run | bool)

--- a/examples/fabproxy-removal/05-update_anchor_peers.yml
+++ b/examples/fabproxy-removal/05-update_anchor_peers.yml
@@ -1,0 +1,35 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+- name: Update anchor peers
+  hosts: localhost
+  vars_files:
+      - common-vars.yml
+      - channels.yml
+  tasks:
+
+      - name: Create the local msp for all organizations
+        hyperledger.fabric_ansible_collection.membership_service_provider_local:
+            api_endpoint: "{{ api_endpoint }}"
+            api_authtype: "{{ api_authtype }}"
+            api_key: "{{ api_key }}"
+            api_secret: "{{ api_secret | default(omit) }}"
+            api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+            operation: "create"
+
+      - name: Remove the previous channels directory if it exists
+        ansible.builtin.file:
+            path: channels_anchor
+            state: absent
+
+      - name: Remove the previous completed channels
+        ansible.builtin.file:
+            path: completed_channels.txt
+            state: absent
+
+      - name: Update channels
+        include_tasks: tasks/05-update-channel.yml
+        loop: "{{ channel_names }}"
+        loop_control:
+            loop_var: channel_name

--- a/examples/fabproxy-removal/README.md
+++ b/examples/fabproxy-removal/README.md
@@ -1,0 +1,5 @@
+# Fabproxy Removal
+
+This is a support project for removing Fabproxy from migrated instances from IBM Blockchain Platform Software as a Service.
+
+Many techniques and processes can be adapted for normal ongoing maintenance processes.

--- a/examples/fabproxy-removal/channels.yml
+++ b/examples/fabproxy-removal/channels.yml
@@ -1,0 +1,7 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+channel_names:
+  - testchainid
+  - channel1

--- a/examples/fabproxy-removal/common-vars.yml
+++ b/examples/fabproxy-removal/common-vars.yml
@@ -1,0 +1,16 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+api_endpoint: https://ibp-console.example.org:32000
+api_authtype: basic
+api_key: xxxxxxxx
+api_secret: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+preferred_url_os: "os"
+preferred_url_legacy: "legacy"
+ordering_service_name: "Orderer"
+ordering_service_node_name: "Orderer_1"
+ordering_service_admin_identity: "Orderer MSP Admin_identity.json"
+ordering_service_msp_id: osmsp
+dry_run: false
+wait_timeout: 600

--- a/examples/fabproxy-removal/tasks/01-renew-ca-tls.yml
+++ b/examples/fabproxy-removal/tasks/01-renew-ca-tls.yml
@@ -1,0 +1,20 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+- name: Renew the TLS Certificate for the Certificate Authority "{{ certificate_authority.name }}"
+  hyperledger.fabric_ansible_collection.certificate_authority_action:
+      api_endpoint: "{{ api_endpoint }}"
+      api_authtype: "{{ api_authtype }}"
+      api_key: "{{ api_key }}"
+      api_secret: "{{ api_secret | default(omit) }}"
+      api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+      name: "{{ certificate_authority.name }}"
+      action: 'renew'
+  register: result
+  when: certificate_authority.imported == False
+
+- name: Fail if the Certificate Authority "{{ certificate_authority.name }}" did not accept the message
+  fail:
+      msg: result.response
+  when: not result.accepted

--- a/examples/fabproxy-removal/tasks/01-update-ca-metadata.yml
+++ b/examples/fabproxy-removal/tasks/01-update-ca-metadata.yml
@@ -1,0 +1,28 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+- name: Update the Certificate Authority metadata for "{{ certificate_authority.name }}"
+  hyperledger.fabric_ansible_collection.certificate_authority_metadata:
+      api_endpoint: "{{ api_endpoint }}"
+      api_authtype: "{{ api_authtype }}"
+      api_key: "{{ api_key }}"
+      api_secret: "{{ api_secret | default(omit) }}"
+      api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+      name: "{{ certificate_authority.name }}"
+      preferred_url: "{{ preferred_url_os }}"
+  register: update_result
+
+- name: Fail if the Certificate Authority "{{ certificate_authority.name }}" was not updated
+  fail:
+      msg: "Certificate Authority {{ certificate_authority.name }} was not updated"
+  when: not update_result.changed
+
+- name: Write the updated certficate authority "{{ certificate_authority.name }}" to a file
+  copy:
+      content: "{{ update_result.certificate_authority | to_nice_json }}"
+      dest: "updated_certficat_authority.json"
+
+- name: Renew TLS Certificates for Certificate Authorities
+  include_tasks: tasks/01-renew-ca-tls.yml
+  when: certificate_authority.imported == False

--- a/examples/fabproxy-removal/tasks/02-create-crypto-update.yml
+++ b/examples/fabproxy-removal/tasks/02-create-crypto-update.yml
@@ -1,0 +1,66 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+- name: Get the Certificate Authority
+  hyperledger.fabric_ansible_collection.certificate_authority_info:
+      api_endpoint: "{{ api_endpoint }}"
+      api_authtype: "{{ api_authtype }}"
+      api_key: "{{ api_key }}"
+      api_secret: "{{ api_secret | default(omit) }}"
+      api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+      name: "{{ certificate_authority.name }}"
+  register: result
+
+- name: Configure the crypto update
+  set_fact:
+      crypto:
+          enrollment:
+              ca:
+                  host: "{{ result.certificate_authority.api_url | urlsplit('hostname') }}"
+                  port: "{{ result.certificate_authority.api_url | urlsplit('port') }}"
+                  tls_cert: "{{ result.certificate_authority.msp.component.tls_cert }}"
+              tlsca:
+                  host: "{{ result.certificate_authority.api_url | urlsplit('hostname') }}"
+                  port: "{{ result.certificate_authority.api_url | urlsplit('port') }}"
+                  tls_cert: "{{result.certificate_authority.msp.component.tls_cert}}"
+
+- name: Get the Nodes associated with the Certificate Authority "{{ certificate_authority.name }}"
+  hyperledger.fabric_ansible_collection.certificate_authority_associated_nodes:
+      api_endpoint: "{{ api_endpoint }}"
+      api_authtype: "{{ api_authtype }}"
+      api_key: "{{ api_key }}"
+      api_secret: "{{ api_secret | default(omit) }}"
+      api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+      certificate_authority: "{{ certificate_authority.name }}"
+  register: nodes
+
+- name: List the Ordering Nodes
+  debug: "msg='Found Ordering Node {{ ordering_service_node.name}}'"
+  loop: "{{ nodes.ordering_service_nodes }}"
+  loop_control:
+      loop_var: ordering_service_node
+      label: "{{ ordering_service_node.name }}"
+
+- name: Update Ordering Nodes associated with "{{ certificate_authority.name }}"
+  include_tasks: tasks/02-update-ordering-node.yml
+  loop: "{{ nodes.ordering_service_nodes }}"
+  loop_control:
+      loop_var: ordering_service_node
+      label: "{{ ordering_service_node.name }}"
+  when: ordering_service_node.imported == False
+
+- name: List the Peers
+  debug: "msg='Found Peer {{ peer.name}}'"
+  loop: "{{ nodes.peers }}"
+  loop_control:
+      loop_var: peer
+      label: "{{ peer.name }}"
+
+- name: Update Peers associated with "{{ certificate_authority.name }}"
+  include_tasks: tasks/02-update-peer.yml
+  loop: "{{ nodes.peers }}"
+  loop_control:
+      loop_var: peer
+      label: "{{ peer.name }}"
+  when: peer.imported == False

--- a/examples/fabproxy-removal/tasks/02-update-ordering-node.yml
+++ b/examples/fabproxy-removal/tasks/02-update-ordering-node.yml
@@ -1,0 +1,40 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+- name: Updating Ordering Node "{{ ordering_service_node.name }}"
+  hyperledger.fabric_ansible_collection.ordering_service_node:
+      api_endpoint: "{{ api_endpoint }}"
+      api_authtype: "{{ api_authtype }}"
+      api_key: "{{ api_key }}"
+      api_secret: "{{ api_secret | default(omit) }}"
+      api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+      name: "{{ ordering_service_node.name }}"
+      crypto: "{{ crypto }}"
+  register: result
+
+- name: Fail if Ordering Service Node "{{ ordering_service_node.name }}" was not updated
+  fail:
+      msg: "Ordering Service Node {{ ordering_service_node.name }} was not updated"
+  when: not result.changed
+
+- name: Write the updated Ordering Service Node "{{ ordering_service_node.name }}" to a file
+  copy:
+      content: "{{ result.ordering_service_node | to_nice_json }}"
+      dest: "updated_ordering_service_node.json"
+
+- name: Restarting Ordering Service Node "{{ ordering_service_node.name }}"
+  hyperledger.fabric_ansible_collection.ordering_service_node_action:
+      api_endpoint: "{{ api_endpoint }}"
+      api_authtype: "{{ api_authtype }}"
+      api_key: "{{ api_key }}"
+      api_secret: "{{ api_secret | default(omit) }}"
+      api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+      name: "{{ ordering_service_node.name }}"
+      action: 'restart'
+  register: result
+
+- name: Fail if Ordering Service Node "{{ ordering_service_node.name }}" did not accept the message
+  fail:
+      msg: result.response
+  when: not result.accepted

--- a/examples/fabproxy-removal/tasks/02-update-peer.yml
+++ b/examples/fabproxy-removal/tasks/02-update-peer.yml
@@ -1,0 +1,40 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+- name: Updating Peer "{{ peer.name }}"
+  hyperledger.fabric_ansible_collection.peer:
+      api_endpoint: "{{ api_endpoint }}"
+      api_authtype: "{{ api_authtype }}"
+      api_key: "{{ api_key }}"
+      api_secret: "{{ api_secret | default(omit) }}"
+      api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+      name: "{{ peer.name }}"
+      crypto: "{{ crypto }}"
+  register: result
+
+- name: Fail if Peer "{{ peer.name }}" was not updated
+  fail:
+      msg: "Peer {{ peer.name }} was not updated"
+  when: not result.changed
+
+- name: Write the updated peer "{{ peer.name }}" to a file
+  copy:
+      content: "{{ result.peer | to_nice_json }}"
+      dest: "updated_peer.json"
+
+- name: Restarting Peer "{{ peer.name }}"
+  hyperledger.fabric_ansible_collection.peer_action:
+      api_endpoint: "{{ api_endpoint }}"
+      api_authtype: "{{ api_authtype }}"
+      api_key: "{{ api_key }}"
+      api_secret: "{{ api_secret | default(omit) }}"
+      api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+      name: "{{ peer.name }}"
+      action: 'restart'
+  register: result
+
+- name: Fail if Peer "{{ peer.name }}" did not accept the message
+  fail:
+      msg: result.response
+  when: not result.accepted

--- a/examples/fabproxy-removal/tasks/03-get-all-nodes-for-ca.yml
+++ b/examples/fabproxy-removal/tasks/03-get-all-nodes-for-ca.yml
@@ -1,0 +1,35 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+- name: Get the Peers associated with the Certificate Authority "{{ certificate_authority.name }}"
+  hyperledger.fabric_ansible_collection.certificate_authority_associated_nodes:
+      api_endpoint: "{{ api_endpoint }}"
+      api_authtype: "{{ api_authtype }}"
+      api_key: "{{ api_key }}"
+      api_secret: "{{ api_secret | default(omit) }}"
+      api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+      certificate_authority: "{{ certificate_authority.name }}"
+  register: nodes
+
+- name: List the Peers
+  debug: "msg='Found Peer {{ peer.name}}'"
+  loop: "{{ nodes.peers }}"
+  loop_control:
+      loop_var: peer
+      label: "{{ peer.name }}"
+
+- name: Migrage Peer addresses associated with "{{ certificate_authority.name }}"
+  include_tasks: tasks/03-migrate-peer-address.yml
+  loop: "{{ nodes.peers }}"
+  loop_control:
+      loop_var: peer
+      label: "{{ peer.name }}"
+
+- name: Migrage imported Ordering Service Node addresses associated with "{{ certificate_authority.name }}"
+  include_tasks: tasks/03-migrate-imported-orderering-node-address.yml
+  loop: "{{ nodes.ordering_service_nodes }}"
+  loop_control:
+      loop_var: ordering_service_node
+      label: "{{ ordering_service_node.name }}"
+  when: ordering_service_node.imported == True

--- a/examples/fabproxy-removal/tasks/03-migrate-imported-orderering-node-address.yml
+++ b/examples/fabproxy-removal/tasks/03-migrate-imported-orderering-node-address.yml
@@ -1,0 +1,20 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+- name: Change the Ordering Service Node "{{ ordering_service_node.name }}" to use the new URLs
+  hyperledger.fabric_ansible_collection.ordering_service_node_metadata:
+      api_endpoint: "{{ api_endpoint }}"
+      api_authtype: "{{ api_authtype }}"
+      api_key: "{{ api_key }}"
+      api_secret: "{{ api_secret | default(omit) }}"
+      api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+      name: "{{ ordering_service_node.name }}"
+      preferred_url: "{{ preferred_url_os }}"
+  register: result
+
+- name: Fail if the Ordering Service Node was not updated
+  fail:
+      msg: "Ordering Service Node {{ ordering_service_node.name }} was not updated"
+  when: not result.changed
+

--- a/examples/fabproxy-removal/tasks/03-migrate-peer-address.yml
+++ b/examples/fabproxy-removal/tasks/03-migrate-peer-address.yml
@@ -1,0 +1,23 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+- name: Change the Peer "{{ peer.name }}" to use the new URLs
+  hyperledger.fabric_ansible_collection.peer_metadata:
+      api_endpoint: "{{ api_endpoint }}"
+      api_authtype: "{{ api_authtype }}"
+      api_key: "{{ api_key }}"
+      api_secret: "{{ api_secret | default(omit) }}"
+      api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+      name: "{{ peer.name }}"
+      preferred_url: "{{ preferred_url_os }}"
+  register: result
+
+- name: Fail if the Peer "{{ peer.name }}" was not updated
+  fail:
+      msg: "Peer {{ peer.name }} was not updated"
+  when: not result.changed
+
+- name: Reenroll TLS Certificates for Peer "{{ peer.name }}"
+  include_tasks: tasks/03-reenroll-peer-tls.yml
+  when: peer.imported == False

--- a/examples/fabproxy-removal/tasks/03-reenroll-peer-tls.yml
+++ b/examples/fabproxy-removal/tasks/03-reenroll-peer-tls.yml
@@ -1,0 +1,20 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+- name: Reenrolling Peer TLS for "{{ peer.name }}"
+  hyperledger.fabric_ansible_collection.peer_action:
+      api_endpoint: "{{ api_endpoint }}"
+      api_authtype: "{{ api_authtype }}"
+      api_key: "{{ api_key }}"
+      api_secret: "{{ api_secret | default(omit) }}"
+      api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+      name: "{{ peer.name }}"
+      action: 'reenroll'
+      type: 'tls_cert'
+  register: result
+
+- name: Fail if Peer "{{ peer.name }}" did not accept the message
+  fail:
+      msg: result.response
+  when: not result.accepted

--- a/examples/fabproxy-removal/tasks/04-update-channel.yml
+++ b/examples/fabproxy-removal/tasks/04-update-channel.yml
@@ -1,0 +1,99 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+- name: Fetch the channel configuration for channel "{{ channel_name }}"
+  hyperledger.fabric_ansible_collection.channel_config:
+      api_endpoint: "{{ api_endpoint }}"
+      api_authtype: "{{ api_authtype }}"
+      api_key: "{{ api_key }}"
+      api_secret: "{{ api_secret | default(omit) }}"
+      api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+      ordering_service: "{{ ordering_service_name }}"
+      identity: "wallet/{{ ordering_service_admin_identity }}"
+      msp_id: "{{ ordering_node_new_url.ordering_service_node.msp_id }}"
+      operation: fetch
+      name: "{{ channel_name }}"
+      path: original_config.bin
+  changed_when: False
+
+- name: Create a copy of channel "{{ channel_name }}" configuration
+  copy:
+      src: original_config.bin
+      dest: updated_config.bin
+  changed_when: False
+
+- name: Update the consenters for channel "{{ channel_name }}"
+  hyperledger.fabric_ansible_collection.channel_consenter:
+      api_endpoint: "{{ api_endpoint }}"
+      api_authtype: "{{ api_authtype }}"
+      api_key: "{{ api_key }}"
+      api_secret: "{{ api_secret | default(omit) }}"
+      api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+      path: updated_config.bin
+      ordering_service_node: "{{ ordering_node_legacy_url.ordering_service_node }}"
+      updated_ordering_service_node: "{{ ordering_node_new_url.ordering_service_node }}"
+  register: update_consenter
+
+- name: Create a channel directory if it does not exist
+  ansible.builtin.file:
+      path: "channels/{{ channel_name }}"
+      state: directory
+      mode: '0755'
+
+- name: Save a copy of the orginal channel config "{{ channel_name }}" to a file
+  copy:
+      content: "{{ update_consenter.original_config_json | to_nice_json }}"
+      dest: "channels/{{ channel_name }}/original_channel_config.json"
+
+- name: Save a copy of the orginal channel config "{{ channel_name }}" to a file
+  copy:
+      content: "{{ update_consenter.updated_config_json | to_nice_json }}"
+      dest: "channels/{{ channel_name }}/updated_channel_config.json"
+
+- name: Compute the channel configuration update for channel "{{ channel_name }}"
+  hyperledger.fabric_ansible_collection.channel_config:
+      operation: compute_update
+      name: "{{ channel_name }}"
+      original: original_config.bin
+      updated: updated_config.bin
+      path: config_update.bin
+  register: compute_update
+  changed_when: False
+
+- name: Sign the channel configuration update for channel "{{ channel_name }}"
+  hyperledger.fabric_ansible_collection.channel_config:
+      # These fields are required here because we need to handle identities
+      # that have been exported from the IBM Blockchain Platform console.
+      api_endpoint: "{{ api_endpoint }}"
+      api_authtype: "{{ api_authtype }}"
+      api_key: "{{ api_key }}"
+      api_secret: "{{ api_secret | default(omit) }}"
+      api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+      operation: sign_update
+      identity: "wallet/{{ ordering_service_admin_identity }}"
+      msp_id: "{{ ordering_node_new_url.ordering_service_node.msp_id }}"
+      name: "{{ channel_name }}"
+      path: config_update.bin
+  when: compute_update.path and not (dry_run | bool)
+
+- name: Apply the channel configuration update for channel "{{ channel_name }}"
+  hyperledger.fabric_ansible_collection.channel_config:
+      api_endpoint: "{{ api_endpoint }}"
+      api_authtype: "{{ api_authtype }}"
+      api_key: "{{ api_key }}"
+      api_secret: "{{ api_secret | default(omit) }}"
+      api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+      operation: apply_update
+      ordering_service: "{{ ordering_service_name }}"
+      identity: "wallet/{{ ordering_service_admin_identity }}"
+      msp_id: "{{ ordering_node_new_url.ordering_service_node.msp_id }}"
+      name: "{{ channel_name }}"
+      path: config_update.bin
+  when: compute_update.path and not (dry_run | bool)
+
+- name: Add the channel to the completed list
+  ansible.builtin.lineinfile:
+      path: completed_channels.txt
+      line: "  - {{ channel_name }}"
+      create: yes

--- a/examples/fabproxy-removal/tasks/05-update-channel.yml
+++ b/examples/fabproxy-removal/tasks/05-update-channel.yml
@@ -1,0 +1,103 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+- name: Fetch the channel configuration for channel "{{ channel_name }}"
+  hyperledger.fabric_ansible_collection.channel_config:
+      api_endpoint: "{{ api_endpoint }}"
+      api_authtype: "{{ api_authtype }}"
+      api_key: "{{ api_key }}"
+      api_secret: "{{ api_secret | default(omit) }}"
+      api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+      ordering_service: "{{ ordering_service_name }}"
+      identity: "wallet/{{ ordering_service_admin_identity }}"
+      msp_id: "{{ ordering_service_msp_id }}"
+      operation: fetch
+      name: "{{ channel_name }}"
+      path: original_config.bin
+  changed_when: False
+
+- name: Create a copy of channel "{{ channel_name }}" configuration
+  copy:
+      src: original_config.bin
+      dest: updated_config.bin
+  changed_when: False
+
+- name: Update the anchor peer addresses for "{{ channel_name }}"
+  hyperledger.fabric_ansible_collection.channel_members:
+      api_endpoint: "{{ api_endpoint }}"
+      api_authtype: "{{ api_authtype }}"
+      api_key: "{{ api_key }}"
+      api_secret: "{{ api_secret | default(omit) }}"
+      api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+      path: updated_config.bin
+      operation: "migrate_addresses_to_os"
+  register: update_addresses
+
+- name: Create a channel directory if it does not exist
+  ansible.builtin.file:
+      path: "channels_anchor/{{ channel_name }}"
+      state: directory
+      mode: '0755'
+  when: update_addresses.changed
+
+- name: Save a copy of the orginal channel config "{{ channel_name }}" to a file
+  copy:
+      content: "{{ update_addresses.original_config_json | to_nice_json }}"
+      dest: "channels_anchor/{{ channel_name }}/original_channel_config.json"
+  when: update_addresses.changed
+
+- name: Save a copy of the orginal channel config "{{ channel_name }}" to a file
+  copy:
+      content: "{{ update_addresses.updated_config_json | to_nice_json }}"
+      dest: "channels_anchor/{{ channel_name }}/updated_channel_config.json"
+  when: update_addresses.changed
+
+- name: Compute the channel configuration update for channel "{{ channel_name }}"
+  hyperledger.fabric_ansible_collection.channel_config:
+      operation: compute_update
+      name: "{{ channel_name }}"
+      original: original_config.bin
+      updated: updated_config.bin
+      path: config_update.bin
+  register: compute_update
+  changed_when: False
+  when: update_addresses.changed
+
+- name: Sign the channel configuration update for channel "{{ channel_name }}"
+  hyperledger.fabric_ansible_collection.channel_config:
+      # These fields are required here because we need to handle identities
+      # that have been exported from the IBM Blockchain Platform console.
+      api_endpoint: "{{ api_endpoint }}"
+      api_authtype: "{{ api_authtype }}"
+      api_key: "{{ api_key }}"
+      api_secret: "{{ api_secret | default(omit) }}"
+      api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+      operation: sign_update_organizations
+      organizations_dir: "organizations"
+      organizations: "{{ update_addresses.organizations }}"
+      name: "{{ channel_name }}"
+      path: config_update.bin
+  when: update_addresses.changed and compute_update.path
+
+- name: Apply the channel configuration update for channel "{{ channel_name }}"
+  hyperledger.fabric_ansible_collection.channel_config:
+      api_endpoint: "{{ api_endpoint }}"
+      api_authtype: "{{ api_authtype }}"
+      api_key: "{{ api_key }}"
+      api_secret: "{{ api_secret | default(omit) }}"
+      api_token_endpoint: "{{ api_token_endpoint | default(omit) }}"
+      operation: apply_update
+      ordering_service: "{{ ordering_service_name }}"
+      identity: "wallet/{{ ordering_service_admin_identity }}"
+      msp_id: "{{ ordering_service_msp_id }}"
+      name: "{{ channel_name }}"
+      path: config_update.bin
+  when: update_addresses.changed and compute_update.path and not (dry_run | bool)
+
+- name: Add the channel to the completed list
+  ansible.builtin.lineinfile:
+      path: completed_channels.txt
+      line: "  - {{ channel_name }}"
+      create: yes
+  when: update_addresses.changed


### PR DESCRIPTION
Add example code for removing fabproxy.

This is only applicable for migrated IBM SaaS instances.

The code is being added to the collection, since there are examples that may be useful for building support processes.