### PR TITLE
Adding an way for complete specifying the peer crypto configurations when creating a new peer using the collection.

### DIFF
--- a/plugins/modules/peer.py
+++ b/plugins/modules/peer.py
@@ -502,7 +502,7 @@ EXAMPLES = '''
               - KUBERNETES_SERVICE_PORT
   loop: "{{ range(1, number_of_peers|int + 1, 1) | list }}"
   loop_control:
-    index_var: peer_idx      
+    index_var: peer_idx
 
 - name: Destroy peer
   hyperledger.fabric_ansible_collection.peer:

--- a/plugins/modules/peer.py
+++ b/plugins/modules/peer.py
@@ -573,11 +573,13 @@ peer:
 
 
 def get_crypto(console, module):
+
     # Get the crypto configuration.
     return {'enrollment': get_crypto_enrollment_config(console, module)}
 
 
 def get_crypto_enrollment_config(console, module):
+
     # Get the crypto configuration.
     return {
         'component': get_crypto_enrollment_component_config(console, module),
@@ -592,6 +594,7 @@ def get_crypto_enrollment_component_config(console, module):
 
 
 def get_crypto_enrollment_ca_config(console, module):
+
     # Get the enrollment configuration for the ordering services MSP.
     certificate_authority = get_certificate_authority_by_module(console, module)
     certificate_authority_url = urllib.parse.urlsplit(certificate_authority.api_url)
@@ -608,6 +611,7 @@ def get_crypto_enrollment_ca_config(console, module):
 
 
 def get_crypto_enrollment_tlsca_config(console, module):
+
     # Get the enrollment configuration for the ordering services TLS.
     certificate_authority = get_certificate_authority_by_module(console, module)
     certificate_authority_url = urllib.parse.urlsplit(certificate_authority.api_url)
@@ -624,6 +628,7 @@ def get_crypto_enrollment_tlsca_config(console, module):
 
 
 def main():
+
     # Create the module.
     argument_spec = dict(
         state=dict(type='str', default='present', choices=['present', 'absent']),
@@ -899,8 +904,7 @@ def main():
             diff = diff_dicts(peer, new_peer)
             for change in diff:
                 if change not in permitted_changes:
-                    raise Exception(
-                        f'{change} cannot be changed from {peer[change]} to {new_peer[change]} for existing peer')
+                    raise Exception(f'{change} cannot be changed from {peer[change]} to {new_peer[change]} for existing peer')
 
             # If a change was supplied to resources, apply the change to the entire resources
             if module.params['resources'] is not None:
@@ -909,6 +913,7 @@ def main():
             # If the peer has changed, apply the changes.
             peer_changed = not equal_dicts(peer, new_peer)
             if peer_changed:
+
                 # Log the differences.
                 module.json_log({
                     'msg': 'differences detected, updating peer',
@@ -934,8 +939,7 @@ def main():
                 crypto = module.params['crypto']
                 if crypto:
                     for config_type in ['enrollment', 'msp']:
-                        expected_admins = crypto.get(config_type, dict()).get('component', dict()).get('admincerts',
-                                                                                                       None)
+                        expected_admins = crypto.get(config_type, dict()).get('component', dict()).get('admincerts', None)
                         if expected_admins:
                             break
             if expected_admins:

--- a/plugins/modules/peer.py
+++ b/plugins/modules/peer.py
@@ -484,9 +484,9 @@ EXAMPLES = '''
           enroll_id: "{{ peer_enrollment_id }}{{ item }}"
           enroll_secret: "{{ peer_enrollment_secret }}"
           csr_hosts:
-              - peers.your.own.domain.localh.st
-              - peer.your.own.domain.localh.st
-              - "127.0.0.1"
+            - peers.your.own.domain.localh.st
+            - peer.your.own.domain.localh.st
+            - "127.0.0.1"
    config_override:
       chaincode:
         externalBuilders:

--- a/plugins/modules/peer.py
+++ b/plugins/modules/peer.py
@@ -487,7 +487,7 @@ EXAMPLES = '''
             - peers.your.own.domain.localh.st
             - peer.your.own.domain.localh.st
             - "127.0.0.1"
-   config_override:
+    config_override:
       chaincode:
         externalBuilders:
           - name: k8s_builder


### PR DESCRIPTION
The parameters "crypto" and "certificate_authority" are mutual exclusive. So, if we provide the crypto configuration, we will have an error when the playbook tries to resolve the CA configuration because the CA name can't be provided using "certificate_authority" parameter.

The changes are:

1. When "crypto" is provided, the ansible will use all provided information and won´t try to retrieve the ca using the name provided on "certificate_authority" parameter.
2. Added new example for peer configuration playbook.